### PR TITLE
[REFACTOR/FE] 토글 컴포넌트 리팩토링 

### DIFF
--- a/client/src/components/_common/TextToggle/TextToggle.stories.tsx
+++ b/client/src/components/_common/TextToggle/TextToggle.stories.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { TextToggle } from './TextToggle';
+
+const meta: Meta<typeof TextToggle> = {
+    title: 'Toggle',
+    component: TextToggle,
+    parameters: {
+        docs: {
+            description: {
+                component: 'Toggle 컴포넌트입니다.',
+            },
+        },
+    },
+};
+
+export default meta;
+type Story = StoryObj<typeof TextToggle>;
+
+export const Primary: Story = {
+    args: {
+        size: 'sm',
+    },
+};
+
+export const mdSize: Story = {
+    args: {
+        size: 'md',
+    },
+};
+
+export const lgSize: Story = {
+    args: {
+        size: 'lg',
+    },
+};

--- a/client/src/components/_common/TextToggle/TextToggle.style.ts
+++ b/client/src/components/_common/TextToggle/TextToggle.style.ts
@@ -1,57 +1,6 @@
 import { css } from '@emotion/react';
 import theme from '@styles/theme';
-import type { CSSObject } from '@emotion/react';
 
-export type Size = 'sm' | 'md' | 'lg';
-
-const getToggleContainerSize = (size: Size) => {
-    switch (size) {
-        case 'sm':
-            return css`
-                width: 3.5rem;
-                height: 1.9rem;
-            `;
-        case 'md':
-            return css`
-                width: 4.5rem;
-                height: 2.4rem;
-            `;
-        case 'lg':
-            return css`
-                width: 5.6rem;
-                height: 3rem;
-            `;
-    }
-};
-const getToggleSize = (size: Size) => {
-    switch (size) {
-        case 'sm':
-            return css`
-                width: 1.5rem;
-                height: 1.5rem;
-            `;
-        case 'md':
-            return css`
-                width: 2rem;
-                height: 2rem;
-            `;
-        case 'lg':
-            return css`
-                width: 2.5rem;
-                height: 2.5rem;
-            `;
-    }
-};
-const getToggleMove = (size: Size) => {
-    switch (size) {
-        case 'sm':
-            return '4rem';
-        case 'md':
-            return '4.5rem';
-        case 'lg':
-            return '5rem';
-    }
-};
 export const hiddenCheckbox = css`
     position: absolute;
     opacity: 0;
@@ -59,38 +8,38 @@ export const hiddenCheckbox = css`
     height: 0;
 `;
 
-export const toggleBackground = (isChecked: boolean, size: Size) => css`
-    position: absolute;
-    top: 0.2rem;
-    left: 0.3rem;
-    ${getToggleSize(size)};
-    align-items: center;
-    justify-content: start;
-    border-radius: 50%;
-    transition: all 0.2s ease-in-out;
-    transform: translateX(0);
-    ${size === 'lg' &&
-    css`
-        top: 0.3rem;
-    `}
-    ${isChecked &&
-    css`
-        transform: translateX(calc(${getToggleMove(size)} - 2.5rem));
-    `}
-
-    background-color: ${theme.colors.white};
+export const toggleContainer = css`
+    display: flex;
+    width: fit-content; /* 내용에 맞게 너비 조정 */
+    height: fit-content;
+    cursor: pointer;
+    padding: 0.3rem;
+    border-radius: 12px;
+    background-color: ${theme.colors.default};
 `;
 
-export const toggleContainer = (isChecked: boolean, size: Size) => {
-    return css`
-        position: relative;
-        cursor: pointer;
-        border-radius: 25px;
-        ${getToggleContainerSize(size)};
-        background-color: ${theme.colors.gray[400]};
-        ${isChecked &&
-        css`
-            background-color: ${theme.colors.default};
-        `}
-    `;
-};
+export const leftTextContainer = (isChecked: boolean) => css`
+    color: ${theme.colors.white};
+    ${!isChecked &&
+    css`
+        color: ${theme.colors.defaultHover};
+        background-color: ${theme.colors.white};
+    `}
+    padding: 0.5rem 1rem;
+    transition: all 0.2s ease-in-out;
+    border-radius: 10px;
+    white-space: nowrap;
+`;
+
+export const rightTextContainer = (isChecked: boolean) => css`
+    color: ${theme.colors.white};
+    ${isChecked &&
+    css`
+        color: ${theme.colors.defaultHover};
+        background-color: ${theme.colors.white};
+    `}
+    transition: all 0.2s ease-in-out;
+    padding: 0.5rem 1rem;
+    border-radius: 10px;
+    white-space: nowrap;
+`;

--- a/client/src/components/_common/TextToggle/TextToggle.style.ts
+++ b/client/src/components/_common/TextToggle/TextToggle.style.ts
@@ -1,0 +1,96 @@
+import { css } from '@emotion/react';
+import theme from '@styles/theme';
+import type { CSSObject } from '@emotion/react';
+
+export type Size = 'sm' | 'md' | 'lg';
+
+const getToggleContainerSize = (size: Size) => {
+    switch (size) {
+        case 'sm':
+            return css`
+                width: 3.5rem;
+                height: 1.9rem;
+            `;
+        case 'md':
+            return css`
+                width: 4.5rem;
+                height: 2.4rem;
+            `;
+        case 'lg':
+            return css`
+                width: 5.6rem;
+                height: 3rem;
+            `;
+    }
+};
+const getToggleSize = (size: Size) => {
+    switch (size) {
+        case 'sm':
+            return css`
+                width: 1.5rem;
+                height: 1.5rem;
+            `;
+        case 'md':
+            return css`
+                width: 2rem;
+                height: 2rem;
+            `;
+        case 'lg':
+            return css`
+                width: 2.5rem;
+                height: 2.5rem;
+            `;
+    }
+};
+const getToggleMove = (size: Size) => {
+    switch (size) {
+        case 'sm':
+            return '4rem';
+        case 'md':
+            return '4.5rem';
+        case 'lg':
+            return '5rem';
+    }
+};
+export const hiddenCheckbox = css`
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+`;
+
+export const toggleBackground = (isChecked: boolean, size: Size) => css`
+    position: absolute;
+    top: 0.2rem;
+    left: 0.3rem;
+    ${getToggleSize(size)};
+    align-items: center;
+    justify-content: start;
+    border-radius: 50%;
+    transition: all 0.2s ease-in-out;
+    transform: translateX(0);
+    ${size === 'lg' &&
+    css`
+        top: 0.3rem;
+    `}
+    ${isChecked &&
+    css`
+        transform: translateX(calc(${getToggleMove(size)} - 2.5rem));
+    `}
+
+    background-color: ${theme.colors.white};
+`;
+
+export const toggleContainer = (isChecked: boolean, size: Size) => {
+    return css`
+        position: relative;
+        cursor: pointer;
+        border-radius: 25px;
+        ${getToggleContainerSize(size)};
+        background-color: ${theme.colors.gray[400]};
+        ${isChecked &&
+        css`
+            background-color: ${theme.colors.default};
+        `}
+    `;
+};

--- a/client/src/components/_common/TextToggle/TextToggle.tsx
+++ b/client/src/components/_common/TextToggle/TextToggle.tsx
@@ -1,20 +1,41 @@
 import React from 'react';
 import type { InputHTMLAttributes } from 'react';
-import { hiddenCheckbox, toggleContainer, toggleBackground } from './TextToggle.style';
-import type { Size } from './TextToggle.style';
+import {
+    hiddenCheckbox,
+    toggleContainer,
+    leftTextContainer,
+    rightTextContainer,
+} from './TextToggle.style';
+import { Text } from '@components';
 
 interface ToggleProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
     leftText?: string;
     rightText?: string;
-    size?: Size;
     isChecked?: boolean;
+    size?: 'sm' | 'md' | 'lg';
     handleToggle?: () => void;
 }
-
-function TextToggle({ isChecked = false, size = 'md', handleToggle, ...props }: ToggleProps) {
+const getSize = (size: 'sm' | 'md' | 'lg') => {
+    switch (size) {
+        case 'sm':
+            return 'subCaptionRegular';
+        case 'md':
+            return 'captionRegular';
+        case 'lg':
+            return 'bodyRegular';
+    }
+};
+function TextToggle({
+    isChecked = false,
+    handleToggle,
+    leftText = '지원사항',
+    rightText = '내 정보',
+    size = 'md',
+    ...props
+}: ToggleProps) {
     return (
         <>
-            <label css={toggleContainer(isChecked, size)}>
+            <label css={toggleContainer}>
                 <input
                     type="checkbox"
                     css={hiddenCheckbox}
@@ -22,7 +43,12 @@ function TextToggle({ isChecked = false, size = 'md', handleToggle, ...props }: 
                     onChange={handleToggle}
                     {...props}
                 />
-                <div css={toggleBackground(isChecked, size)} />
+                <Text as="div" type={getSize(size)} sx={leftTextContainer(isChecked)}>
+                    {leftText}
+                </Text>
+                <Text as="div" type={getSize(size)} sx={rightTextContainer(isChecked)}>
+                    {rightText}
+                </Text>
             </label>
         </>
     );

--- a/client/src/components/_common/TextToggle/TextToggle.tsx
+++ b/client/src/components/_common/TextToggle/TextToggle.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import type { InputHTMLAttributes } from 'react';
+import { hiddenCheckbox, toggleContainer, toggleBackground } from './TextToggle.style';
+import type { Size } from './TextToggle.style';
+
+interface ToggleProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
+    leftText?: string;
+    rightText?: string;
+    size?: Size;
+    isChecked?: boolean;
+    handleToggle?: () => void;
+}
+
+function TextToggle({ isChecked = false, size = 'md', handleToggle, ...props }: ToggleProps) {
+    return (
+        <>
+            <label css={toggleContainer(isChecked, size)}>
+                <input
+                    type="checkbox"
+                    css={hiddenCheckbox}
+                    checked={isChecked}
+                    onChange={handleToggle}
+                    {...props}
+                />
+                <div css={toggleBackground(isChecked, size)} />
+            </label>
+        </>
+    );
+}
+
+export { TextToggle };

--- a/client/src/components/_common/TextToggle/index.tsx
+++ b/client/src/components/_common/TextToggle/index.tsx
@@ -1,0 +1,1 @@
+export * from './TextToggle';

--- a/client/src/components/_common/Toggle/Toggle.stories.tsx
+++ b/client/src/components/_common/Toggle/Toggle.stories.tsx
@@ -19,25 +19,18 @@ type Story = StoryObj<typeof Toggle>;
 
 export const Primary: Story = {
     args: {
-        width: '4.1rem',
-        variant: 'primary',
+        size: 'sm',
     },
 };
 
-export const text: Story = {
+export const mdSize: Story = {
     args: {
-        width: '12rem',
-        variant: 'text',
-        leftText: 'leftText',
-        rightText: 'rightText',
+        size: 'md',
     },
 };
 
-export const secondText: Story = {
+export const lgSize: Story = {
     args: {
-        width: '12rem',
-        variant: 'secondText',
-        leftText: 'leftText',
-        rightText: 'rightText',
+        size: 'lg',
     },
 };

--- a/client/src/components/_common/Toggle/Toggle.style.ts
+++ b/client/src/components/_common/Toggle/Toggle.style.ts
@@ -59,7 +59,7 @@ export const hiddenCheckbox = css`
     height: 0;
 `;
 
-export const toggleBackground = (isChecked: boolean, size: Size) => css`
+export const toggleCircle = (isChecked: boolean, size: Size) => css`
     position: absolute;
     top: 0.2rem;
     left: 0.3rem;

--- a/client/src/components/_common/Toggle/Toggle.style.ts
+++ b/client/src/components/_common/Toggle/Toggle.style.ts
@@ -9,12 +9,12 @@ const getToggleContainerSize = (size: Size) => {
         case 'sm':
             return css`
                 width: 3.5rem;
-                height: 1.9rem;
+                height: 2rem;
             `;
         case 'md':
             return css`
                 width: 4.5rem;
-                height: 2.4rem;
+                height: 2.5rem;
             `;
         case 'lg':
             return css`
@@ -29,16 +29,22 @@ const getToggleSize = (size: Size) => {
             return css`
                 width: 1.5rem;
                 height: 1.5rem;
+                top: 0.2rem;
+                left: 0.3rem;
             `;
         case 'md':
             return css`
                 width: 2rem;
                 height: 2rem;
+                top: 0.2rem;
+                left: 0.3rem;
             `;
         case 'lg':
             return css`
                 width: 2.5rem;
                 height: 2.5rem;
+                top: 0.2rem;
+                left: 0.3rem;
             `;
     }
 };
@@ -61,8 +67,6 @@ export const hiddenCheckbox = css`
 
 export const toggleCircle = (isChecked: boolean, size: Size) => css`
     position: absolute;
-    top: 0.2rem;
-    left: 0.3rem;
     ${getToggleSize(size)};
     align-items: center;
     justify-content: start;

--- a/client/src/components/_common/Toggle/Toggle.style.ts
+++ b/client/src/components/_common/Toggle/Toggle.style.ts
@@ -1,7 +1,57 @@
 import { css } from '@emotion/react';
 import theme from '@styles/theme';
-import type { ToggleVariant } from './Toggle';
+import type { CSSObject } from '@emotion/react';
 
+export type Size = 'sm' | 'md' | 'lg';
+
+const getToggleContainerSize = (size: Size) => {
+    switch (size) {
+        case 'sm':
+            return css`
+                width: 3.5rem;
+                height: 1.9rem;
+            `;
+        case 'md':
+            return css`
+                width: 4.5rem;
+                height: 2.4rem;
+            `;
+        case 'lg':
+            return css`
+                width: 5.6rem;
+                height: 3rem;
+            `;
+    }
+};
+const getToggleSize = (size: Size) => {
+    switch (size) {
+        case 'sm':
+            return css`
+                width: 1.5rem;
+                height: 1.5rem;
+            `;
+        case 'md':
+            return css`
+                width: 2rem;
+                height: 2rem;
+            `;
+        case 'lg':
+            return css`
+                width: 2.5rem;
+                height: 2.5rem;
+            `;
+    }
+};
+const getToggleMove = (size: Size) => {
+    switch (size) {
+        case 'sm':
+            return '4rem';
+        case 'md':
+            return '4.5rem';
+        case 'lg':
+            return '5rem';
+    }
+};
 export const hiddenCheckbox = css`
     position: absolute;
     opacity: 0;
@@ -9,142 +59,38 @@ export const hiddenCheckbox = css`
     height: 0;
 `;
 
-const toggleBase = css`
-    position: relative;
-    display: inline-flex;
+export const toggleBackground = (isChecked: boolean, size: Size) => css`
+    position: absolute;
+    top: 0.2rem;
+    left: 0.3rem;
+    ${getToggleSize(size)};
     align-items: center;
-    cursor: pointer;
-    user-select: none;
-    justify-content: space-between;
+    justify-content: start;
+    border-radius: 50%;
+    transition: all 0.2s ease-in-out;
+    transform: translateX(0);
+    ${size === 'lg' &&
+    css`
+        top: 0.3rem;
+    `}
+    ${isChecked &&
+    css`
+        transform: translateX(calc(${getToggleMove(size)} - 2.5rem));
+    `}
+
+    background-color: ${theme.colors.white};
 `;
 
-export const toggleContainer = (variant: ToggleVariant, width: string, isChecked: boolean) => {
-    switch (variant) {
-        case 'primary':
-            return css`
-                ${toggleBase}
-
-                padding: 0.2rem 0.1rem;
-                ${isChecked
-                    ? `background-color: ${theme.colors.disabled};`
-                    : `background-color: ${theme.colors.default};`}
-                border-radius: 1.1rem;
-                box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-                width: ${width};
-            `;
-        case 'text':
-            return css`
-                ${toggleBase}
-                padding: 0.2rem;
-                background-color: white;
-                border-radius: 0.375rem;
-                box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-                width: ${width};
-            `;
-        case 'secondText':
-            return css`
-                ${toggleBase}
-                padding: 0.2rem;
-                background-color: ${theme.colors.default};
-                border-radius: 1.2rem;
-                box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-                width: ${width};
-            `;
-        default:
-            return css`
-                ${toggleBase}
-                padding: 0.2rem 0.1rem;
-                ${isChecked
-                    ? `background-color: ${theme.colors.disabled};`
-                    : `background-color: ${theme.colors.default};`}
-                border-radius: 1.1rem;
-                box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-                width: ${width};
-            `;
-    }
-};
-
-const textBase = css`
-    display: flex;
-    align-items: center;
-    gap: 0.375rem;
-    padding: 0.5rem 1.125rem;
-    ${theme.typography.subCaptionSemibold}
-    white-space: nowrap;
-`;
-const noneTextBase = css`
-    display: flex;
-    align-items: center;
-    border-radius: 5rem;
-    padding: 1rem 1rem;
-`;
-
-export const leftTextContainer = (variant: ToggleVariant, isChecked: boolean) => {
-    switch (variant) {
-        case 'primary':
-            return css`
-                ${noneTextBase}
-                ${isChecked
-                    ? `background-color: ${theme.colors.white};`
-                    : `color: ${theme.colors.gray[700]}`}
-            `;
-        case 'text':
-            return css`
-                border-radius: 0.25rem;
-                ${textBase}
-                ${isChecked
-                    ? ` color: ${theme.colors.default};   background-color: #f4f7ff; `
-                    : ` color: ${theme.colors.gray[500]};`}
-            `;
-        case 'secondText':
-            return css`
-                border-radius: 1rem;
-                ${textBase}
-                ${isChecked
-                    ? `color: ${theme.colors.default}; background-color: ${theme.colors.white};`
-                    : `color: ${theme.colors.white};`}
-            `;
-        default:
-            return css`
-                ${noneTextBase}
-                ${isChecked
-                    ? `background-color: ${theme.colors.white};`
-                    : `color: ${theme.colors.gray[500]}`}
-            `;
-    }
-};
-
-export const rightTextContainer = (variant: ToggleVariant, isChecked: boolean) => {
-    switch (variant) {
-        case 'primary':
-            return css`
-                ${noneTextBase}
-                ${!isChecked
-                    ? `background-color: ${theme.colors.white};`
-                    : `color: ${theme.colors.gray[500]}`}
-            `;
-        case 'text':
-            return css`
-                border-radius: 0.25rem;
-                ${textBase}
-                ${!isChecked
-                    ? `color: ${theme.colors.default};background-color: #f4f7ff;`
-                    : `color: ${theme.colors.gray[500]};`}
-            `;
-        case 'secondText':
-            return css`
-                border-radius: 1rem;
-                ${textBase}
-                ${!isChecked
-                    ? `color: ${theme.colors.default};background-color: ${theme.colors.white};`
-                    : `color: ${theme.colors.white};`}
-            `;
-        default:
-            return css`
-                ${noneTextBase}
-                ${!isChecked
-                    ? `background-color: ${theme.colors.white};`
-                    : `color: ${theme.colors.gray[500]};`}
-            `;
-    }
+export const toggleContainer = (isChecked: boolean, size: Size) => {
+    return css`
+        position: relative;
+        cursor: pointer;
+        border-radius: 25px;
+        ${getToggleContainerSize(size)};
+        background-color: ${theme.colors.gray[400]};
+        ${isChecked &&
+        css`
+            background-color: ${theme.colors.default};
+        `}
+    `;
 };

--- a/client/src/components/_common/Toggle/Toggle.style.ts
+++ b/client/src/components/_common/Toggle/Toggle.style.ts
@@ -69,10 +69,6 @@ export const toggleCircle = (isChecked: boolean, size: Size) => css`
     border-radius: 50%;
     transition: all 0.2s ease-in-out;
     transform: translateX(0);
-    ${size === 'lg' &&
-    css`
-        top: 0.3rem;
-    `}
     ${isChecked &&
     css`
         transform: translateX(calc(${getToggleMove(size)} - 2.5rem));

--- a/client/src/components/_common/Toggle/Toggle.style.ts
+++ b/client/src/components/_common/Toggle/Toggle.style.ts
@@ -29,21 +29,21 @@ const getToggleSize = (size: Size) => {
             return css`
                 width: 1.5rem;
                 height: 1.5rem;
-                top: 0.2rem;
+                top: 0.23rem;
                 left: 0.3rem;
             `;
         case 'md':
             return css`
                 width: 2rem;
                 height: 2rem;
-                top: 0.2rem;
+                top: 0.23rem;
                 left: 0.3rem;
             `;
         case 'lg':
             return css`
                 width: 2.5rem;
                 height: 2.5rem;
-                top: 0.2rem;
+                top: 0.25rem;
                 left: 0.3rem;
             `;
     }

--- a/client/src/components/_common/Toggle/Toggle.tsx
+++ b/client/src/components/_common/Toggle/Toggle.tsx
@@ -1,35 +1,20 @@
 import React from 'react';
 import type { InputHTMLAttributes } from 'react';
-import {
-    hiddenCheckbox,
-    toggleContainer,
-    leftTextContainer,
-    rightTextContainer,
-} from './Toggle.style';
+import { hiddenCheckbox, toggleContainer, toggleBackground } from './Toggle.style';
+import type { Size } from './Toggle.style';
 
-export type ToggleVariant = 'primary' | 'text' | 'secondText';
-
-interface ToggleProps extends InputHTMLAttributes<HTMLInputElement> {
-    variant?: ToggleVariant;
+interface ToggleProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
     leftText?: string;
     rightText?: string;
-    width?: string;
-    isChecked: boolean;
+    size?: Size;
+    isChecked?: boolean;
     handleToggle?: () => void;
 }
 
-function Toggle({
-    variant = 'primary',
-    width = '11rem',
-    leftText = '',
-    rightText = '',
-    isChecked,
-    handleToggle,
-    ...props
-}: ToggleProps) {
+function Toggle({ isChecked = false, size = 'md', handleToggle, ...props }: ToggleProps) {
     return (
         <>
-            <label css={toggleContainer(variant, width, isChecked)}>
+            <label css={toggleContainer(isChecked, size)}>
                 <input
                     type="checkbox"
                     css={hiddenCheckbox}
@@ -37,8 +22,7 @@ function Toggle({
                     onChange={handleToggle}
                     {...props}
                 />
-                <span css={leftTextContainer(variant, isChecked)}>{leftText}</span>
-                <span css={rightTextContainer(variant, isChecked)}>{rightText}</span>
+                <div css={toggleBackground(isChecked, size)} />
             </label>
         </>
     );

--- a/client/src/components/_common/Toggle/Toggle.tsx
+++ b/client/src/components/_common/Toggle/Toggle.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { InputHTMLAttributes } from 'react';
-import { hiddenCheckbox, toggleContainer, toggleBackground } from './Toggle.style';
+import { hiddenCheckbox, toggleContainer, toggleCircle } from './Toggle.style';
 import type { Size } from './Toggle.style';
 
 interface ToggleProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
@@ -22,7 +22,7 @@ function Toggle({ isChecked = false, size = 'md', handleToggle, ...props }: Togg
                     onChange={handleToggle}
                     {...props}
                 />
-                <div css={toggleBackground(isChecked, size)} />
+                <div css={toggleCircle(isChecked, size)} />
             </label>
         </>
     );

--- a/client/src/components/_common/index.tsx
+++ b/client/src/components/_common/index.tsx
@@ -10,3 +10,4 @@ export * from './Toggle';
 export * from './Divider';
 export * from './Calendar';
 export * from './LoadingSpinner';
+export * from './TextToggle';

--- a/client/src/pages/TestPage/index.tsx
+++ b/client/src/pages/TestPage/index.tsx
@@ -2,15 +2,32 @@ import React, { useState } from 'react';
 import { Calendar, Button } from '@components';
 import dayjs from 'dayjs';
 import { MainCard } from '@components';
+import { Toggle, TextToggle } from '@components';
+import { useToggle } from '@hooks/useToggle';
 
 function TestPage() {
     const [text, setText] = useState('');
-    const onChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
-        setText(e.target.value);
-    };
+    const { isChecked, handleToggle } = useToggle();
+
     return (
         <>
-            <MainCard />
+            <br />
+            <Toggle isChecked={isChecked} handleToggle={handleToggle} size="sm" />
+            <br />
+            <Toggle isChecked={isChecked} handleToggle={handleToggle} size="md" />
+            <br />
+            <Toggle isChecked={isChecked} handleToggle={handleToggle} size="lg" />
+            <br />
+            <TextToggle
+                isChecked={isChecked}
+                handleToggle={handleToggle}
+                size="sm"
+                leftText="안녕하세요"
+            />
+            <br />
+            <TextToggle isChecked={isChecked} handleToggle={handleToggle} size="md" />
+            <br />
+            <TextToggle isChecked={isChecked} handleToggle={handleToggle} size="lg" />
         </>
     );
 }


### PR DESCRIPTION
## 📌 관련 이슈
`closed #180`

## 🛠️ 작업 내용
- [ ] 기본 토글 컴포넌트 애니메이션 추가
- [ ] TextToggle과 분리
- [ ] TextToggle을 Toggle 컴포넌트와 분리하여 재구현하고 애니메이션 추가

## 🎯 리뷰 포인트

-  Toggle과 TextToggle 컴포넌트 분리 및 개선

현재 Toggle과 TextToggle 컴포넌트의 애니메이션을 다르게 구현하였습니다.

기본 Toggle 같은 경우 width가 고정값이기 때문에 슬라이더 애니메이션으로 구현하였지만
TextToggle같은 경우 여러 레퍼런스를 찾아봤을 때 기본적으로 적어둔 글자크기의 width를 기반으로 슬라이더 애니메이션을 구현해놓았기 때문에 글자 길이가 바뀔 때 width가 달라져서 Toggle이 깨지는 것을 확인하였습니다.

이 문제는 동적으로 width를 계산하여 해결할 수도 있지만, 
현재 구현된 애니메이션 방식도 괜찮다는 피드백을 받아 그대로 유지하기로 했습니다.

### 토글 컴포넌트를 리팩토링하면서 다음과 같은 수정 사항이 있습니다

1. Toggle 컴포넌트의 사이즈 옵션을 width 값으로만 받던 방식에서 sm, md, lg 세 가지 사이즈로 구분하였습니다.
2. 기존에 하나의 컴포넌트로 관리하던 Toggle과 TextToggle을 각각의 특성에 맞게 별도 컴포넌트로 분리하였습니다.

## ⏳ 작업 시간
추정 시간:   3~4시간
실제 시간:   5시간
