### PR TITLE
[FE] 모집공고 카드 눌렀을 때 나오는 Dialog, Page 구현

### DIFF
--- a/client/src/components/ClubBox/ClubBox.style.ts
+++ b/client/src/components/ClubBox/ClubBox.style.ts
@@ -18,4 +18,7 @@ export const clubBoxContainer = css`
 
 export const clubBoxItem = css`
     display: flex;
+    @media (max-width: ${theme.breakpoint.mobile}) {
+        gap: 2rem;
+    }
 `;

--- a/client/src/components/ClubNavigation/ClubNavigation.style.ts
+++ b/client/src/components/ClubNavigation/ClubNavigation.style.ts
@@ -36,7 +36,7 @@ export const navigationSlider = (position: number, width: string) => css`
     bottom: 0;
     margin: 0;
     z-index: 1;
-    border-radius: 50%;
+    border-radius: 25px;
     border: 0.5px solid ${theme.colors.black};
     width: ${width};
     transform: translateX(${position}rem);

--- a/client/src/components/ClubNavigation/ClubNavigation.style.ts
+++ b/client/src/components/ClubNavigation/ClubNavigation.style.ts
@@ -26,6 +26,10 @@ export const navigationButton = (isActive: boolean) => css`
     transition: color 0.1s;
 `;
 
+export const divider = css`
+    width: 100%;
+    background-color: ${theme.colors.gray[200]};
+`;
 export const navigationSlider = (position: number, width: string) => css`
     display: absolute;
     left: 0;

--- a/client/src/components/ClubNavigation/ClubNavigation.style.ts
+++ b/client/src/components/ClubNavigation/ClubNavigation.style.ts
@@ -1,18 +1,17 @@
 import { css } from '@emotion/react';
 import theme from '@styles/theme';
 
-export const NavigationContainer = css`
-    width: 100%;
+export const navigationContainer = css`
     display: flex;
-    justify-content: space-between;
-
-    gap: 0.5rem;
+    width: 100%;
+    gap: 1rem;
 `;
 
-export const NavigationButton = (isActive: boolean) => css`
+export const navigationButton = (isActive: boolean) => css`
     ${theme.typography.bodySemibold}
     color: ${theme.colors.gray[500]};
     margin-bottom: 0.5rem;
+    padding-left: 0;
     :hover {
         color: ${theme.colors.gray[500]};
     }
@@ -25,4 +24,19 @@ export const NavigationButton = (isActive: boolean) => css`
         }
     `}
     transition: color 0.1s;
+`;
+
+export const navigationSlider = (position: number, width: string) => css`
+    display: absolute;
+    left: 0;
+    bottom: 0;
+    margin: 0;
+    z-index: 1;
+    border-radius: 50%;
+    border: 0.5px solid ${theme.colors.black};
+    width: ${width};
+    transform: translateX(${position}rem);
+    transition:
+        transform 0.3s ease-in-out,
+        width 0.2s ease-in-out 0.05s;
 `;

--- a/client/src/components/ClubNavigation/ClubNavigation.tsx
+++ b/client/src/components/ClubNavigation/ClubNavigation.tsx
@@ -1,44 +1,59 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Divider, Button } from '@components';
-import { NavigationButton, NavigationContainer } from './ClubNavigation.style';
+import { navigationButton, navigationContainer, navigationSlider } from './ClubNavigation.style';
 import type { ClubNavigationProps } from './types';
 
 function ClubNavigation(props: ClubNavigationProps) {
     // prop destruction
-    const { navigationItem, navItem } = props;
+    const { navigationItem } = props;
     // lib hooks
     // initial values
     // state, ref, querystring hooks
     const [active, setActive] = useState<string>(navigationItem[0].title);
+    const [sliderPosition, setSliderPosition] = useState<number>(0);
+    const [sliderWidth, setSliderWidth] = useState<string>(navigationItem[0].width);
 
     // form hooks
     // query hooks
     // calculated values
     const activeContent = navigationItem.find((content) => content.title === active);
 
+    const calculateSliderPosition = (title: string) => {
+        let position: number = 0;
+        for (const content of navigationItem) {
+            if (content.title === title) {
+                setSliderPosition(position);
+                setSliderWidth(content.width);
+            } else {
+                const width = parseInt(content.width);
+                position += width + 1.5;
+            }
+        }
+    };
     // handlers
+    const handlePosition = (title: string) => {
+        setActive(title);
+        calculateSliderPosition(title);
+    };
     // effects
-
     return (
         <>
-            <div css={NavigationContainer}>
-                <div css={{ display: 'flex' }}>
-                    {navigationItem &&
-                        navigationItem.map((content) => (
-                            <Button
-                                key={content.title}
-                                variant="text"
-                                size="s"
-                                sx={NavigationButton(active === content.title)}
-                                onClick={() => setActive(content.title)}
-                            >
-                                {content.title}
-                            </Button>
-                        ))}
-                </div>
-                {navItem}
+            <div css={navigationContainer}>
+                {navigationItem &&
+                    navigationItem.map((content) => (
+                        <Button
+                            key={content.title}
+                            variant="text"
+                            size="s"
+                            sx={navigationButton(active === content.title)}
+                            onClick={() => handlePosition(content.title)}
+                        >
+                            {content.title}
+                        </Button>
+                    ))}
             </div>
-            <Divider />
+            <hr css={navigationSlider(sliderPosition, sliderWidth)} />
+            <Divider sx={{ display: 'relative' }} />
             {activeContent && activeContent.page}
         </>
     );

--- a/client/src/components/ClubNavigation/ClubNavigation.tsx
+++ b/client/src/components/ClubNavigation/ClubNavigation.tsx
@@ -1,6 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { Divider, Button } from '@components';
-import { navigationButton, navigationContainer, navigationSlider } from './ClubNavigation.style';
+import {
+    divider,
+    navigationButton,
+    navigationContainer,
+    navigationSlider,
+} from './ClubNavigation.style';
 import type { ClubNavigationProps } from './types';
 
 function ClubNavigation(props: ClubNavigationProps) {
@@ -52,8 +57,9 @@ function ClubNavigation(props: ClubNavigationProps) {
                         </Button>
                     ))}
             </div>
-            <hr css={navigationSlider(sliderPosition, sliderWidth)} />
-            <Divider sx={{ display: 'relative' }} />
+            <div css={divider}>
+                <hr css={navigationSlider(sliderPosition, sliderWidth)} />
+            </div>
             {activeContent && activeContent.page}
         </>
     );

--- a/client/src/components/ClubNavigation/types.ts
+++ b/client/src/components/ClubNavigation/types.ts
@@ -2,10 +2,10 @@ import type { ReactNode } from 'react';
 
 export interface NavigationItem {
     title: string;
-    page: ReactNode; // React 컴포넌트나 JSX 엘리먼트를 포함할 수 있음을 나타냅니다.
+    page: ReactNode;
+    width: string;
 }
 
 export interface ClubNavigationProps {
     navigationItem: NavigationItem[];
-    navItem?: ReactNode; // 선택적 prop으로, React 컴포넌트나 JSX 엘리먼트를 포함할 수 있습니다.
 }

--- a/client/src/components/Header/Header.style.ts
+++ b/client/src/components/Header/Header.style.ts
@@ -15,20 +15,8 @@ export const headerBarContainer = css`
 export const homeNavContainer = css`
     display: flex;
     justify-content: space-between;
-    width: 100rem;
-
-    // 840px ~ 1200px
-    @media (max-width: ${theme.breakpoint.desktop}) {
-        width: 90rem;
-    }
-    // 600px ~ 840px
-    @media (max-width: ${theme.breakpoint.tablet}) {
-        width: 70rem;
-    }
-    // 0px ~ 600px
-    @media (max-width: ${theme.breakpoint.mobile}) {
-        width: 35rem;
-    }
+    width: 100%;
+    max-width: 100rem;
 `;
 
 export const homeImage = css`

--- a/client/src/components/MainCard/MainCard.tsx
+++ b/client/src/components/MainCard/MainCard.tsx
@@ -41,6 +41,7 @@ function MainCard({
     // form hooks
     // query hooks
     // calculated values
+    const hashTagList = hashTag.map((tag) => `#${tag} `);
     // handlers
     // effects
     return (
@@ -71,11 +72,9 @@ function MainCard({
                 </Text>
             </div>
             <div css={cardFooterContainer}>
-                {hashTag.map((tag: string) => (
-                    <Text key={tag} type="captionLight" color="primary" noWrap cropped>
-                        #{tag}
-                    </Text>
-                ))}
+                <Text type="captionLight" color="primary" noWrap cropped>
+                    {hashTagList}
+                </Text>
             </div>
         </Link>
     );

--- a/client/src/components/RecruitCard/RecruitCard.tsx
+++ b/client/src/components/RecruitCard/RecruitCard.tsx
@@ -7,13 +7,12 @@ import {
     deadlineText,
 } from './RecruitCard.style';
 import { Text } from '@components';
-import { Link } from 'react-router-dom';
 import dayjs from 'dayjs';
 import type { RecruitCardProps } from './types';
 
 function RecruitCard(props: RecruitCardProps) {
-    const { title, content, deadline, link, hashtags } = props;
     // prop destruction
+    const { title, content, deadline, hashtags, onClick } = props;
     // lib hooks
     // initial values
     const today = dayjs().format('YYYY-MM-DD');
@@ -38,29 +37,31 @@ function RecruitCard(props: RecruitCardProps) {
 
     // effects
     return (
-        <Link css={recruitCardContainer} to={link}>
-            <div css={recruitCardHeader}>
-                <Text noWrap cropped>
-                    {title}
-                </Text>
-                <Text color="caption" sx={deadlineText(diffDay)} noWrap>
-                    {calculateDeadline}
-                </Text>
-            </div>
-
-            <div css={recruitCardBody}>
-                <Text noWrap cropped>
-                    {content}
-                </Text>
-            </div>
-            <div css={recruitCardFooter}>
-                {hashtags.map((tag) => (
-                    <Text key={tag} type="subCaptionRegular" color="primary" noWrap cropped>
-                        #{tag}
+        <>
+            <button css={recruitCardContainer} onClick={onClick}>
+                <div css={recruitCardHeader}>
+                    <Text noWrap cropped>
+                        {title}
                     </Text>
-                ))}
-            </div>
-        </Link>
+                    <Text color="caption" sx={deadlineText(diffDay)} noWrap>
+                        {calculateDeadline}
+                    </Text>
+                </div>
+
+                <div css={recruitCardBody}>
+                    <Text noWrap cropped>
+                        {content}
+                    </Text>
+                </div>
+                <div css={recruitCardFooter}>
+                    {hashtags.map((tag) => (
+                        <Text key={tag} type="subCaptionRegular" color="primary" noWrap cropped>
+                            #{tag}
+                        </Text>
+                    ))}
+                </div>
+            </button>
+        </>
     );
 }
 

--- a/client/src/components/RecruitCard/RecruitCard.tsx
+++ b/client/src/components/RecruitCard/RecruitCard.tsx
@@ -21,6 +21,7 @@ function RecruitCard(props: RecruitCardProps) {
     // form hooks
     // query hooks
     // calculated values
+    const hashtagList = hashtags.map((tag) => `#${tag} `);
     const diffDay = formattedDeadline.diff(today, 'day');
     const calculateDeadline = useMemo(() => {
         if (diffDay > 7) {
@@ -54,11 +55,9 @@ function RecruitCard(props: RecruitCardProps) {
                     </Text>
                 </div>
                 <div css={recruitCardFooter}>
-                    {hashtags.map((tag) => (
-                        <Text key={tag} type="subCaptionRegular" color="primary" noWrap cropped>
-                            #{tag}
-                        </Text>
-                    ))}
+                    <Text type="subCaptionRegular" color="primary" noWrap cropped>
+                        {hashtagList}
+                    </Text>
                 </div>
             </button>
         </>

--- a/client/src/components/RecruitCard/types.ts
+++ b/client/src/components/RecruitCard/types.ts
@@ -2,6 +2,6 @@ export interface RecruitCardProps {
     title: string;
     content: string;
     deadline: string;
-    link: string;
     hashtags: string[];
+    onClick?: () => void;
 }

--- a/client/src/components/RecruitDialog/RecruitDialog.style.tsx
+++ b/client/src/components/RecruitDialog/RecruitDialog.style.tsx
@@ -1,0 +1,56 @@
+import { css } from '@emotion/react';
+import theme from '@styles/theme';
+export const DialogContainer = css`
+    display: flex;
+    flex-direction: column;
+    max-width: 90rem;
+    max-height: 60rem;
+    @media (min-width: ${theme.breakpoint.mobileMini}) {
+        padding: 2rem 2rem 1rem 2rem;
+    }
+    @media (min-width: ${theme.breakpoint.mobile}) {
+        padding: 3rem 4rem 1rem 4rem;
+        max-height: 80rem;
+    }
+`;
+export const headerContainer = css`
+    display: flex;
+    flex-direction: column;
+    align-items: start;
+    padding-left: 3rem;
+    gap: 0.5rem;
+`;
+export const contentContainer = css`
+    flex-direction: column;
+    justify-content: start;
+    height: 100%;
+    width: 100%;
+    gap: 5rem;
+    overflow-y: auto;
+`;
+export const textContainer = css`
+    padding: 0 2rem;
+`;
+
+export const imageListContainer = css`
+    display: grid;
+    justify-content: center;
+    padding: 2rem 3rem;
+    gap: 0.5rem;
+    grid-template-columns: repeat(4, 1fr);
+`;
+
+export const imageItem = css`
+    aspect-ratio: 1 / 1;
+    border-radius: 10px;
+    background-color: transparent;
+`;
+
+export const actionContainer = css`
+    padding-bottom: 2rem;
+    padding-top: 3rem;
+`;
+export const applyButton = css`
+    width: 100%;
+    max-width: 30rem;
+`;

--- a/client/src/components/RecruitDialog/RecruitDialog.style.tsx
+++ b/client/src/components/RecruitDialog/RecruitDialog.style.tsx
@@ -21,6 +21,7 @@ export const headerContainer = css`
     gap: 0.5rem;
 `;
 export const contentContainer = css`
+    position: relative;
     flex-direction: column;
     justify-content: start;
     height: 100%;
@@ -28,6 +29,7 @@ export const contentContainer = css`
     gap: 5rem;
     overflow-y: auto;
 `;
+
 export const textContainer = css`
     padding: 0 2rem;
 `;
@@ -35,6 +37,7 @@ export const textContainer = css`
 export const imageListContainer = css`
     display: grid;
     justify-content: center;
+    width: 100%;
     padding: 2rem 3rem;
     gap: 0.5rem;
     grid-template-columns: repeat(4, 1fr);
@@ -49,6 +52,16 @@ export const imageItem = css`
 export const actionContainer = css`
     padding-bottom: 2rem;
     padding-top: 3rem;
+    @media (max-width: ${theme.breakpoint.mobile}) {
+        position: fixed;
+        width: 100%;
+        bottom: 1rem;
+        left: 0;
+        right: 0;
+        padding: 0.5rem 4rem;
+        z-index: 100;
+        opacity: 0.9;
+    }
 `;
 export const applyButton = css`
     width: 100%;

--- a/client/src/components/RecruitDialog/RecruitDialog.tsx
+++ b/client/src/components/RecruitDialog/RecruitDialog.tsx
@@ -24,7 +24,7 @@ function RecruitDialog(props: RecruitmentDialogProps) {
         'https://images.unsplash.com/photo-1496989981497-27d69cdad83e?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MTh8fCVFQiU4RiU5OSVFQyU5NSU4NCVFQiVBNiVBQ3xlbnwwfHwwfHx8MA%3D%3D',
         'https://plus.unsplash.com/premium_photo-1673795753320-a9df2df4461e?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxmZWF0dXJlZC1waG90b3MtZmVlZHw0Mnx8fGVufDB8fHx8fA%3D%3D',
         'https://images.unsplash.com/photo-1745605443047-ea774bf4a77f?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxmZWF0dXJlZC1waG90b3MtZmVlZHwzMnx8fGVufDB8fHx8fA%3D%3D',
-        'https://cf-ea.everytime.kr/attach/232/74463499/everytime-1741847240041.jpg?Expires=1746087876&Key-Pair-Id=APKAICU6XZKH23IGASFA&Signature=WSpbdOC9ZMACA54-77OBuUediahTLZxr4G0qeFVAuhDAAmjGx1oRoIoqBTSlzIuTB0uP8RGjOg5A~odr7wYgkaeAKJupvvK5~jPj7iv-1KFzSugNXM35l~KExqNlQr8tcyvjeQ7niXb5UkWCkObR2H50zu6RjSpSvZ6l6cvCEXkpryfo6aREwM8YOm1wLoZzyPi3UEmh9uOdipHTaYYoesl~pxXQ8B~Qfcn5FtM1algsXQ3ctXxrW2XSHBCWP-JxwvYykEN8k3ruTcOEqkcxMZQApSLE2Ynr4XFZC4emLx~ui8MiCradQiy35sw0UM4YqbnqdAEZpcFXDL7qD0NZ7Q__',
+        'https://d32gkk464bsqbe.cloudfront.net/JTI08fg3oWjuMKWf6pO94MCxv5M=/400x300/company-profiles/o/b23a5925970125281c7ad70138c1bee3d79df7ca.png',
     ];
     // state, ref, querystring hooks
     // form hooks

--- a/client/src/components/RecruitDialog/RecruitDialog.tsx
+++ b/client/src/components/RecruitDialog/RecruitDialog.tsx
@@ -11,10 +11,12 @@ import {
     imageListContainer,
     imageItem,
 } from './RecruitDialog.style';
+import { useRouter } from '@hooks/useRouter';
 
 function RecruitDialog(props: RecruitmentDialogProps) {
     // prop destruction
-    const { open, handleClose } = props;
+    const { open, handleClose, link = 'recruitment' } = props;
+    const { goTo } = useRouter();
     // lib hooks
     // initial values
     const images = [
@@ -38,7 +40,7 @@ function RecruitDialog(props: RecruitmentDialogProps) {
             backdrop={true}
             handleClose={handleClose}
         >
-            <Dialog.Header handleClose={handleClose} sx={headerContainer} closeIcon={true}>
+            <Dialog.Header handleClose={handleClose} sx={headerContainer}>
                 <Text as="h1" type="h1Semibold">
                     모집공고
                 </Text>
@@ -90,7 +92,10 @@ function RecruitDialog(props: RecruitmentDialogProps) {
                 <Button
                     variant="primary"
                     size="xl"
-                    onClick={handleClose}
+                    onClick={() => {
+                        handleClose?.();
+                        goTo(link);
+                    }}
                     sx={applyButton}
                     zIndex={10}
                 >

--- a/client/src/components/RecruitDialog/RecruitDialog.tsx
+++ b/client/src/components/RecruitDialog/RecruitDialog.tsx
@@ -46,11 +46,12 @@ function RecruitDialog(props: RecruitmentDialogProps) {
                 </Text>
                 <Button
                     variant="text"
-                    size="xs"
+                    size="s"
                     onClick={() => {
                         handleClose?.();
                         goTo('recruitment');
                     }}
+                    sx={{ paddingLeft: '0.2rem' }}
                 >
                     전체 페이지로 보기
                 </Button>

--- a/client/src/components/RecruitDialog/RecruitDialog.tsx
+++ b/client/src/components/RecruitDialog/RecruitDialog.tsx
@@ -44,7 +44,14 @@ function RecruitDialog(props: RecruitmentDialogProps) {
                 <Text as="h1" type="h1Semibold">
                     모집공고
                 </Text>
-                <Button variant="text" size="xs">
+                <Button
+                    variant="text"
+                    size="xs"
+                    onClick={() => {
+                        handleClose?.();
+                        goTo('recruitment');
+                    }}
+                >
                     전체 페이지로 보기
                 </Button>
             </Dialog.Header>

--- a/client/src/components/RecruitDialog/RecruitDialog.tsx
+++ b/client/src/components/RecruitDialog/RecruitDialog.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { Dialog, ClubBox, Text, Button, Image } from '@components';
+import type { RecruitmentDialogProps } from './types';
+import {
+    actionContainer,
+    applyButton,
+    contentContainer,
+    DialogContainer,
+    headerContainer,
+    textContainer,
+    imageListContainer,
+    imageItem,
+} from './RecruitDialog.style';
+
+function RecruitDialog(props: RecruitmentDialogProps) {
+    // prop destruction
+    const { open, handleClose } = props;
+    // lib hooks
+    // initial values
+    const images = [
+        'https://ticketimage.interpark.com/Play/image/large/24/24013437_p.gif',
+        'https://images.unsplash.com/photo-1496989981497-27d69cdad83e?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MTh8fCVFQiU4RiU5OSVFQyU5NSU4NCVFQiVBNiVBQ3xlbnwwfHwwfHx8MA%3D%3D',
+        'https://plus.unsplash.com/premium_photo-1673795753320-a9df2df4461e?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxmZWF0dXJlZC1waG90b3MtZmVlZHw0Mnx8fGVufDB8fHx8fA%3D%3D',
+        'https://images.unsplash.com/photo-1745605443047-ea774bf4a77f?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxmZWF0dXJlZC1waG90b3MtZmVlZHwzMnx8fGVufDB8fHx8fA%3D%3D',
+        'https://cf-ea.everytime.kr/attach/232/74463499/everytime-1741847240041.jpg?Expires=1746087876&Key-Pair-Id=APKAICU6XZKH23IGASFA&Signature=WSpbdOC9ZMACA54-77OBuUediahTLZxr4G0qeFVAuhDAAmjGx1oRoIoqBTSlzIuTB0uP8RGjOg5A~odr7wYgkaeAKJupvvK5~jPj7iv-1KFzSugNXM35l~KExqNlQr8tcyvjeQ7niXb5UkWCkObR2H50zu6RjSpSvZ6l6cvCEXkpryfo6aREwM8YOm1wLoZzyPi3UEmh9uOdipHTaYYoesl~pxXQ8B~Qfcn5FtM1algsXQ3ctXxrW2XSHBCWP-JxwvYykEN8k3ruTcOEqkcxMZQApSLE2Ynr4XFZC4emLx~ui8MiCradQiy35sw0UM4YqbnqdAEZpcFXDL7qD0NZ7Q__',
+    ];
+    // state, ref, querystring hooks
+    // form hooks
+    // query hooks
+    // calculated values
+    // handlers
+    // effects
+    return (
+        <Dialog
+            open={open}
+            size="full"
+            sx={DialogContainer}
+            backdrop={true}
+            handleClose={handleClose}
+        >
+            <Dialog.Header handleClose={handleClose} sx={headerContainer} closeIcon={true}>
+                <Text as="h1" type="h1Semibold">
+                    모집공고
+                </Text>
+                <Button variant="text" size="xs">
+                    전체 페이지로 보기
+                </Button>
+            </Dialog.Header>
+            <Dialog.Content sx={contentContainer}>
+                <ClubBox />
+                <Text textAlign="start" sx={textContainer}>
+                    ` EN#은 설립된 지 올해로 23년 된 역사 깊은 세종대학교 프로그래밍 학술
+                    동아리입니다. ‘C#을 즐기자’라는 목적으로 설립된 EN#은 현재 다양한 언어와 기술
+                    스택을 공부하며, WEB과 APP 분야에서 활발히 활동 중입니다.최종적으로 실제
+                    자기만의 WEB, APP서비스를 구현하여 운영하는 경험을 목표로 하고 있습니다. EN#은
+                    설립된 지 올해로 23년 된 역사 깊은 세종대학교 프로그래밍 학술 동아리입니다.
+                    ‘C#을 즐기자’라는 목적으로 설립된 EN#은 현재 다양한 언어와 기술 스택을 공부하며,
+                    WEB과 APP 분야에서 활발히 활동 중입니다. 최종적으로 실제 자기만의 WEB,
+                    APP서비스를 구현하여 운영하는 경험을 목표로 하고 있습니다. ` 동아리입니다. ‘C#을
+                    즐기자’라는 목적으로 설립된 EN#은 현재 다양한 언어와 기술 스택을 공부하며, WEB과
+                    APP 분야에서 활발히 활동 중입니다.최종적으로 실제 자기만의 WEB, APP서비스를
+                    구현하여 운영하는 경험을 목표로 하고 있습니다. EN#은 설립된 지 올해로 23년 된
+                    역사 깊은 세종대학교 프로그래밍 학술 동아리입니다. ‘C#을 즐기자’라는 목적으로
+                    설립된 EN#은 현재 다양한 언어와 기술 스택을 공부하며, WEB과 APP 분야에서 활발히
+                    활동 중입니다. 최종적으로 실제 자기만의 WEB, APP서비스를 구현하여 운영하는
+                    경험을 목표로 하고 있습니다. ` 스택을 공부하며, WEB과 APP 분야에서 활발히 활동
+                    중입니다.최종적으로 실제 자기만의 WEB, APP서비스를 구현하여 운영하는 경험을
+                    목표로 하고 있습니다. EN#은 설립된 지 올해로 23년 된 역사 깊은 세종대학교
+                    프로그래밍 학술 동아리입니다. ‘C#을 즐기자’라는 목적으로 설립된 EN#은 현재
+                    다양한 언어와 기술 스택을 공부하며, WEB과 APP 분야에서 활발히 활동 중입니다.
+                    최종적으로 실제 자기만의 WEB, APP서비스를 구현하여 운영하는 경험을 목표로 하고
+                    있습니다. ` 스택을 공부하며, WEB과 APP 분야에서 활발히 활동 중입니다.최종적으로
+                    실제 자기만의 WEB, APP서비스를 구현하여 운영하는 경험을 목표로 하고 있습니다.
+                    EN#은 설립된 지 올해로 23년 된 역사 깊은 세종대학교 프로그래밍 학술
+                    동아리입니다. ‘C#을 즐기자’라는 목적으로 설립된 EN#은 현재 다양한 언어와 기술
+                    스택을 공부하며, WEB과 APP 분야에서 활발히 활동 중입니다. 최종적으로 실제
+                    자기만의 WEB, APP서비스를 구현하여 운영하는 경험을 목표로 하고 있습니다. `
+                </Text>
+
+                <div css={imageListContainer}>
+                    {images &&
+                        images.map((url) => (
+                            <div css={imageItem} key={url}>
+                                <Image src={url} alt="동아리 사진" />
+                            </div>
+                        ))}
+                </div>
+            </Dialog.Content>
+            <Dialog.Action sx={actionContainer}>
+                <Button
+                    variant="primary"
+                    size="xl"
+                    onClick={handleClose}
+                    sx={applyButton}
+                    zIndex={10}
+                >
+                    지원하기
+                </Button>
+            </Dialog.Action>
+        </Dialog>
+    );
+}
+export { RecruitDialog };

--- a/client/src/components/RecruitDialog/index.tsx
+++ b/client/src/components/RecruitDialog/index.tsx
@@ -1,0 +1,1 @@
+export * from './RecruitDialog';

--- a/client/src/components/RecruitDialog/types.ts
+++ b/client/src/components/RecruitDialog/types.ts
@@ -1,0 +1,4 @@
+export interface RecruitmentDialogProps {
+    open?: boolean;
+    handleClose?: () => void;
+}

--- a/client/src/components/RecruitDialog/types.ts
+++ b/client/src/components/RecruitDialog/types.ts
@@ -1,4 +1,5 @@
 export interface RecruitmentDialogProps {
     open?: boolean;
     handleClose?: () => void;
+    link?: string;
 }

--- a/client/src/components/_common/Dialog/Dialog.tsx
+++ b/client/src/components/_common/Dialog/Dialog.tsx
@@ -60,7 +60,7 @@ function BaseDialog({
                     <>
                         <div
                             css={backdropContainer}
-                            onClick={() => backdrop && handleClose()}
+                            onClick={() => backdrop && handleClose?.()}
                             aria-hidden="true"
                         />
                         <div css={[dialogContainer, dialogSize[size], sx]}>{children}</div>

--- a/client/src/components/index.tsx
+++ b/client/src/components/index.tsx
@@ -18,3 +18,4 @@ export * from './ClubNavigation';
 export * from './ClubBox';
 export * from './ImageDialog';
 export * from './MainCard';
+export * from './RecruitDialog';

--- a/client/src/layouts/ManagerLayout/ManagerLayout.tsx
+++ b/client/src/layouts/ManagerLayout/ManagerLayout.tsx
@@ -13,8 +13,8 @@ function ManagerLayout() {
                     <SideBar />
                     <Outlet />
                 </div>
+                <Footer />
             </div>
-            <Footer />
         </>
     );
 }

--- a/client/src/layouts/UserLayout/UserLayout.tsx
+++ b/client/src/layouts/UserLayout/UserLayout.tsx
@@ -12,8 +12,8 @@ function UserLayout() {
                 <div css={contentContainer}>
                     <Outlet />
                 </div>
+                <Footer />
             </div>
-            <Footer />
         </>
     );
 }

--- a/client/src/pages/ClubDetailPage/ClubDetailPage.style.ts
+++ b/client/src/pages/ClubDetailPage/ClubDetailPage.style.ts
@@ -13,6 +13,7 @@ export const clubDetailPageContainer = css`
 
 export const contentContainer = css`
     max-width: 90rem;
+    min-height: 130rem;
     width: 100%;
     height: 100%;
     background-color: ${theme.colors.white};

--- a/client/src/pages/ClubDetailPage/ClubDetailPage.tsx
+++ b/client/src/pages/ClubDetailPage/ClubDetailPage.tsx
@@ -19,10 +19,17 @@ function ClubDetailPage() {
         {
             title: '동아리 소개',
             page: <ClubIntroPage />,
+            width: '7.5rem',
         },
         {
             title: '모집 공고',
             page: <RecruitmentPage />,
+            width: '6.4rem',
+        },
+        {
+            title: '테스트',
+            page: <RecruitmentPage />,
+            width: '4.6rem',
         },
     ];
     const tempImage = 'https://cdn.pixabay.com/photo/2013/07/26/08/08/shield-167582_640.jpg';

--- a/client/src/pages/ClubDetailPage/ClubIntroPage/ClubIntro.style.ts
+++ b/client/src/pages/ClubDetailPage/ClubIntroPage/ClubIntro.style.ts
@@ -11,6 +11,7 @@ export const textContainer = css`
 export const imageListContainer = css`
     display: grid;
     justify-content: center;
+    width: 100%;
     grid-template-columns: repeat(3, 1fr); // 기본 3열
     padding: 4rem 3rem;
     gap: 0.5rem;

--- a/client/src/pages/ClubDetailPage/RecruitmentPage/RecruitmentPage.style.ts
+++ b/client/src/pages/ClubDetailPage/RecruitmentPage/RecruitmentPage.style.ts
@@ -16,4 +16,5 @@ export const recruitCell = css`
     display: flex;
     justify-content: center;
     align-items: center;
+    background: transparent;
 `;

--- a/client/src/pages/ClubDetailPage/RecruitmentPage/RecruitmentPage.tsx
+++ b/client/src/pages/ClubDetailPage/RecruitmentPage/RecruitmentPage.tsx
@@ -36,7 +36,7 @@ function RecruitmentPage() {
             content:
                 'Flutter 또는 React Native를 이용한 크로스 플랫폼 앱 개발 프로젝트를 함께 할 팀원 모집합니다.',
             deadline: '2025-05-30',
-            hashtags: ['모바일', 'Flutter', 'React Native', '프로젝트'],
+            hashtags: ['모바일', 'Flutter', 'React Native', '프로젝트', 'React Native', '프로젝트'],
             link: '/recruitment/3',
         },
         {

--- a/client/src/pages/ClubDetailPage/RecruitmentPage/RecruitmentPage.tsx
+++ b/client/src/pages/ClubDetailPage/RecruitmentPage/RecruitmentPage.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
-import { RecruitCard } from '@components';
+import { RecruitCard, RecruitDialog } from '@components';
 import { recruitCell, recruitmentContainer } from './RecruitmentPage.style';
+import { useDialog } from '@hooks/useDialog';
+
 function RecruitmentPage() {
     // prop destruction
     // lib hooks
+    const { open, openDialog, closeDialog } = useDialog();
     // initial values
     // state, ref, querystring hooks
     // form hooks
@@ -55,20 +58,23 @@ function RecruitmentPage() {
     ];
 
     return (
-        <div css={recruitmentContainer}>
-            {recruitListData &&
-                recruitListData.map((cardData) => (
-                    <div css={recruitCell} key={cardData.title}>
-                        <RecruitCard
-                            title={cardData.title}
-                            content={cardData.content}
-                            deadline={cardData.deadline}
-                            hashtags={cardData.hashtags}
-                            link={cardData.link}
-                        />
-                    </div>
-                ))}
-        </div>
+        <>
+            <div css={recruitmentContainer}>
+                {recruitListData &&
+                    recruitListData.map((cardData) => (
+                        <div css={recruitCell} key={cardData.title}>
+                            <RecruitCard
+                                title={cardData.title}
+                                content={cardData.content}
+                                deadline={cardData.deadline}
+                                hashtags={cardData.hashtags}
+                                onClick={openDialog}
+                            />
+                        </div>
+                    ))}
+            </div>
+            {open && <RecruitDialog open={open} handleClose={closeDialog} />}
+        </>
     );
 }
 

--- a/client/src/pages/MainPage/MainPage.style.ts
+++ b/client/src/pages/MainPage/MainPage.style.ts
@@ -5,6 +5,7 @@ export const mainPageContainer = css`
     height: 100%;
     width: 100%;
     max-width: 110rem;
+    min-height: 130rem;
     @media (min-width: ${theme.breakpoint.mobile}) {
         padding: 0 2rem;
     }

--- a/client/src/pages/RecruitmentPage/RecruitmentPage.style.tsx
+++ b/client/src/pages/RecruitmentPage/RecruitmentPage.style.tsx
@@ -1,0 +1,93 @@
+import { css } from '@emotion/react';
+import theme from '@styles/theme';
+
+export const recruitmentContainer = css`
+    width: 100%;
+    height: 100%;
+    background-color: ${theme.colors.gray[100]};
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 2rem 0;
+`;
+
+export const contentContainer = css`
+    position: relative;
+    max-width: 90rem;
+    min-height: 130rem;
+    width: 100%;
+    flex: 1;
+    background-color: ${theme.colors.white};
+    border-radius: 10px;
+    border: 1px solid ${theme.colors.gray[200]};
+    padding: 2rem 3rem;
+    @media (min-width: ${theme.breakpoint.tabletMini}) {
+        padding: 4rem 6rem;
+    }
+`;
+
+export const contentHeader = css`
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-bottom: 4rem;
+    padding: 0 1rem;
+`;
+export const headerSubContainer = css`
+    display: flex;
+    justify-content: space-between;
+`;
+export const clubNameContainer = css`
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+`;
+export const applyButtonAtDesktop = css`
+    width: 25rem;
+    height: 4rem;
+    @media (max-width: ${theme.breakpoint.mobile}) {
+        display: none;
+    }
+`;
+
+export const contentBody = css`
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    gap: 10rem;
+`;
+export const textContainer = css`
+    padding: 0 2rem;
+`;
+
+export const applyButtonAtMobile = css`
+    position: fixed;
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    bottom: 1rem;
+    left: 0;
+    right: 0;
+    padding: 0 4rem;
+    z-index: 100;
+    opacity: 0.9;
+    @media (min-width: ${theme.breakpoint.mobile}) {
+        display: none;
+    }
+`;
+export const imageListContainer = css`
+    display: grid;
+    justify-content: center;
+    grid-template-columns: repeat(3, 1fr); // 기본 3열
+    padding: 4rem 3rem;
+    gap: 0.5rem;
+    @media (min-width: 480px) {
+        grid-template-columns: repeat(4, 1fr);
+    }
+`;
+
+export const imageItem = css`
+    aspect-ratio: 1 / 1;
+    border-radius: 10px;
+    background-color: transparent;
+`;

--- a/client/src/pages/RecruitmentPage/RecruitmentPage.style.tsx
+++ b/client/src/pages/RecruitmentPage/RecruitmentPage.style.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import theme from '@styles/theme';
 
 export const recruitmentContainer = css`
+    position: relative;
     width: 100%;
     height: 100%;
     background-color: ${theme.colors.gray[100]};
@@ -12,7 +13,6 @@ export const recruitmentContainer = css`
 `;
 
 export const contentContainer = css`
-    position: relative;
     max-width: 90rem;
     min-height: 130rem;
     width: 100%;
@@ -66,7 +66,7 @@ export const applyButtonAtMobile = css`
     left: 0;
     right: 0;
     padding: 0 4rem;
-    //z-index: 100;
+    z-index: 100;
     opacity: 0.9;
     @media (min-width: ${theme.breakpoint.mobile}) {
         display: none;

--- a/client/src/pages/RecruitmentPage/RecruitmentPage.style.tsx
+++ b/client/src/pages/RecruitmentPage/RecruitmentPage.style.tsx
@@ -62,14 +62,11 @@ export const textContainer = css`
 
 export const applyButtonAtMobile = css`
     position: fixed;
-    display: flex;
-    justify-content: center;
-    width: 100%;
     bottom: 1rem;
     left: 0;
     right: 0;
     padding: 0 4rem;
-    z-index: 100;
+    //z-index: 100;
     opacity: 0.9;
     @media (min-width: ${theme.breakpoint.mobile}) {
         display: none;
@@ -81,6 +78,7 @@ export const imageListContainer = css`
     grid-template-columns: repeat(3, 1fr); // 기본 3열
     padding: 4rem 3rem;
     gap: 0.5rem;
+    width: 100%;
     @media (min-width: 480px) {
         grid-template-columns: repeat(4, 1fr);
     }

--- a/client/src/pages/RecruitmentPage/RecruitmentPage.tsx
+++ b/client/src/pages/RecruitmentPage/RecruitmentPage.tsx
@@ -107,15 +107,13 @@ function RecruitmentPage() {
                             ))}
                     </div>
                 </div>
-
-                <div css={applyButtonAtMobile}>
-                    <Button size="full">지원하기</Button>
-                </div>
-
-                {open && imageUrl && (
-                    <ImageDialog open={open} handleClose={closeDialog} imageUrl={imageUrl} />
-                )}
             </div>
+            <div css={applyButtonAtMobile}>
+                <Button size="full">지원하기</Button>
+            </div>
+            {open && imageUrl && (
+                <ImageDialog open={open} handleClose={closeDialog} imageUrl={imageUrl} />
+            )}
         </div>
     );
 }

--- a/client/src/pages/RecruitmentPage/RecruitmentPage.tsx
+++ b/client/src/pages/RecruitmentPage/RecruitmentPage.tsx
@@ -1,0 +1,122 @@
+import React, { useState } from 'react';
+import { Text, Button, Tag, ClubBox, Image, ImageDialog } from '@components';
+import {
+    clubNameContainer,
+    contentContainer,
+    recruitmentContainer,
+    imageListContainer,
+    imageItem,
+    contentHeader,
+    contentBody,
+    headerSubContainer,
+    applyButtonAtDesktop,
+    textContainer,
+    applyButtonAtMobile,
+} from './RecruitmentPage.style';
+import { useDialog } from '@hooks/useDialog';
+
+function RecruitmentPage() {
+    // prop destruction
+    const { open, openDialog, closeDialog } = useDialog();
+    // lib hooks
+    // initial values
+    const images = [
+        'https://ticketimage.interpark.com/Play/image/large/24/24013437_p.gif',
+        'https://images.unsplash.com/photo-1496989981497-27d69cdad83e?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MTh8fCVFQiU4RiU5OSVFQyU5NSU4NCVFQiVBNiVBQ3xlbnwwfHwwfHx8MA%3D%3D',
+        'https://plus.unsplash.com/premium_photo-1673795753320-a9df2df4461e?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxmZWF0dXJlZC1waG90b3MtZmVlZHw0Mnx8fGVufDB8fHx8fA%3D%3D',
+        'https://images.unsplash.com/photo-1745605443047-ea774bf4a77f?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxmZWF0dXJlZC1waG90b3MtZmVlZHwzMnx8fGVufDB8fHx8fA%3D%3D',
+        'https://d32gkk464bsqbe.cloudfront.net/JTI08fg3oWjuMKWf6pO94MCxv5M=/400x300/company-profiles/o/b23a5925970125281c7ad70138c1bee3d79df7ca.png',
+    ];
+    // state, ref, querystring hooks
+    const [imageUrl, setImageUrl] = useState<string>();
+    // form hooks
+    // query hooks
+    // calculated values
+    // handlers
+    const handleImageClick = (url: string) => {
+        setImageUrl(url);
+    };
+    // effects
+
+    return (
+        <div css={recruitmentContainer}>
+            <div css={contentContainer}>
+                <div css={contentHeader}>
+                    <Text as="h1" type="h1Semibold" textAlign="start">
+                        프론트엔드 모집
+                    </Text>
+                    <div css={headerSubContainer}>
+                        <div css={clubNameContainer}>
+                            <Text as="h4" type="h4Light" color="caption">
+                                EN#
+                            </Text>
+                            <Tag variant="progress" text="모집중" />
+                        </div>
+                        <Button variant="primary" size="xl" sx={applyButtonAtDesktop}>
+                            지원하기
+                        </Button>
+                    </div>
+                </div>
+
+                <div css={contentBody}>
+                    <ClubBox />
+                    <Text textAlign="start" sx={textContainer}>
+                        ` EN#은 설립된 지 올해로 23년 된 역사 깊은 세종대학교 프로그래밍 학술
+                        동아리입니다. ‘C#을 즐기자’라는 목적으로 설립된 EN#은 현재 다양한 언어와
+                        기술 스택을 공부하며, WEB과 APP 분야에서 활발히 활동 중입니다.최종적으로
+                        실제 자기만의 WEB, APP서비스를 구현하여 운영하는 경험을 목표로 하고
+                        있습니다. EN#은 설립된 지 올해로 23년 된 역사 깊은 세종대학교 프로그래밍
+                        학술 동아리입니다. ‘C#을 즐기자’라는 목적으로 설립된 EN#은 현재 다양한
+                        언어와 기술 스택을 공부하며, WEB과 APP 분야에서 활발히 활동 중입니다.
+                        최종적으로 실제 자기만의 WEB, APP서비스를 구현하여 운영하는 경험을 목표로
+                        하고 있습니다. ` 동아리입니다. ‘C#을 즐기자’라는 목적으로 설립된 EN#은 현재
+                        다양한 언어와 기술 스택을 공부하며, WEB과 APP 분야에서 활발히 활동
+                        중입니다.최종적으로 실제 자기만의 WEB, APP서비스를 구현하여 운영하는 경험을
+                        목표로 하고 있습니다. EN#은 설립된 지 올해로 23년 된 역사 깊은 세종대학교
+                        프로그래밍 학술 동아리입니다. ‘C#을 즐기자’라는 목적으로 설립된 EN#은 현재
+                        다양한 언어와 기술 스택을 공부하며, WEB과 APP 분야에서 활발히 활동 중입니다.
+                        최종적으로 실제 자기만의 WEB, APP서비스를 구현하여 운영하는 경험을 목표로
+                        하고 있습니다. ` 스택을 공부하며, WEB과 APP 분야에서 활발히 활동
+                        중입니다.최종적으로 실제 자기만의 WEB, APP서비스를 구현하여 운영하는 경험을
+                        목표로 하고 있습니다. EN#은 설립된 지 올해로 23년 된 역사 깊은 세종대학교
+                        프로그래밍 학술 동아리입니다. ‘C#을 즐기자’라는 목적으로 설립된 EN#은 현재
+                        다양한 언어와 기술 스택을 공부하며, WEB과 APP 분야에서 활발히 활동 중입니다.
+                        최종적으로 실제 자기만의 WEB, APP서비스를 구현하여 운영하는 경험을 목표로
+                        하고 있습니다. ` 스택을 공부하며, WEB과 APP 분야에서 활발히 활동
+                        중입니다.최종적으로 실제 자기만의 WEB, APP서비스를 구현하여 운영하는 경험을
+                        목표로 하고 있습니다. EN#은 설립된 지 올해로 23년 된 역사 깊은 세종대학교
+                        프로그래밍 학술 동아리입니다. ‘C#을 즐기자’라는 목적으로 설립된 EN#은 현재
+                        다양한 언어와 기술 스택을 공부하며, WEB과 APP 분야에서 활발히 활동 중입니다.
+                        최종적으로 실제 자기만의 WEB, APP서비스를 구현하여 운영하는 경험을 목표로
+                        하고 있습니다. `
+                    </Text>
+
+                    <div css={imageListContainer}>
+                        {images &&
+                            images.map((url) => (
+                                <button
+                                    css={imageItem}
+                                    key={url}
+                                    onClick={() => {
+                                        openDialog();
+                                        handleImageClick(url);
+                                    }}
+                                >
+                                    <Image src={url} alt="동아리 사진" />
+                                </button>
+                            ))}
+                    </div>
+                </div>
+
+                <div css={applyButtonAtMobile}>
+                    <Button size="full">지원하기</Button>
+                </div>
+
+                {open && imageUrl && (
+                    <ImageDialog open={open} handleClose={closeDialog} imageUrl={imageUrl} />
+                )}
+            </div>
+        </div>
+    );
+}
+export { RecruitmentPage };

--- a/client/src/pages/RecruitmentPage/index.tsx
+++ b/client/src/pages/RecruitmentPage/index.tsx
@@ -1,0 +1,1 @@
+export * from './RecruitmentPage';

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -4,3 +4,4 @@ export * from './NotFoundPage';
 export * from './ClubDetailPage';
 export * from './MainPage';
 export * from './ClubDetailPage';
+export * from './RecruitmentPage';

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -1,6 +1,14 @@
 import React from 'react';
 import { createBrowserRouter } from 'react-router';
-import { TestPage, NotFoundPage, LoginPage, RegisterPage, MainPage, ClubDetailPage } from './pages';
+import {
+    TestPage,
+    NotFoundPage,
+    LoginPage,
+    RegisterPage,
+    MainPage,
+    ClubDetailPage,
+    RecruitmentPage,
+} from './pages';
 import { UserLayout, ManagerLayout } from './layouts';
 
 const router = createBrowserRouter([
@@ -14,7 +22,7 @@ const router = createBrowserRouter([
             { path: 'register', element: <RegisterPage /> },
             { path: 'detail', element: <ClubDetailPage /> },
             { path: 'test', element: <TestPage /> },
-            { path: 'detail', element: <ClubDetailPage /> },
+            { path: 'detail/recruitment', element: <RecruitmentPage /> },
         ],
     },
     {


### PR DESCRIPTION
## 📌 관련 이슈
`closed #182`

## 🛠️ 작업 내용
- [x] 모집공고 카드 눌렀을 때 보이는 Dialog 구현
- [x] Dialog에서 전체페이지로 보기 눌렀을 때 보는 페이지 구현

## 🎯 리뷰 포인트

1. RecruitmentPage 구현
모집공고 카드를 눌렀을 때 보이는 DIalog 컴포넌트입니다.
모바일 화면을 고려하여 반응형으로 개발하였고 모바일 화면에서는 지원하기 버튼의 위치를 모바일 화면 기준 아래에 배치해두어
사용자가 가장 아래로 이동하지 않아도 바로 지원하기 버튼을 누를 수 있도록 하였고, 버튼에 요소가 가려지지 않게 opacity를 조절하였습니다.

2. RecruitmentPage 구현
위에서 만든 Dialog에서 전체페이지로 보기를 눌렀을 때 보이는 화면으로 모집 공고를 전체 화면으로 보는 페이지 입니다.
이 페이지에서 지원하기 버튼은 상단에 위치에 있다가 모바일로 변경될 때 하단에 고정될 수 있도록 하였습니다.

3. Header 요소간 width 간격 조정
기존에 breakpoint마다 width를 조절하는 방식은 width가 조절될 때 마다 부자연스러운 움직임을 보여서
width: 100%를 주되 max-width값으로 자연스럽게 길이를 조절하도록 수정하였습니다.

4. 데이터 하드코딩
현재 각 페이지와 Dialog 같은 경우 API가 제작되지 않아서 각각의 데이터를 하드 코딩해논 상태입니다.
추후에 API 요청을 통해 받은 데이터로 화면을 렌더링 할 수 있도록 수정하겠습니다.

## ⏳ 작업 시간
추정 시간:  2일
실제 시간:  2일
