### PR TITLE
[FE] AccessToken 및 RefreshToken 인증 플로우 구현

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -33,7 +33,8 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-easy-crop": "^5.4.2",
-        "react-router-dom": "^7.1.5"
+        "react-router-dom": "^7.1.5",
+        "zustand": "^5.0.6"
     },
     "devDependencies": {
         "@babel/core": "^7.26.7",

--- a/client/src/api/common/httpClient.ts
+++ b/client/src/api/common/httpClient.ts
@@ -1,3 +1,4 @@
+import { useAuthStore } from '@stores/authStore';
 import { HttpError } from './httpError';
 import type { CreateClientOptions } from './types';
 import { BASE_URL } from '@constants/api';
@@ -27,12 +28,20 @@ const httpClient = {
 
     async createHttpRequest({ method, url, headers, body, isAuthRequire }: CreateClientOptions) {
         const fullUrl = new URL(url, BASE_URL).toString();
+
+        const {accessToken} = useAuthStore.getState();
+
+        const authHeaders = new Headers(headers)
+
+        authHeaders.set('Content-Type', 'application/json');
+
+        if(accessToken && isAuthRequire){
+            authHeaders.set('Authorization', `Bearer ${accessToken}`)
+        }
+
         const response = await fetch(fullUrl, {
             method: method,
-            headers: {
-                'Content-Type': 'application/json',
-                ...headers,
-            },
+            headers: authHeaders,
             body: body ? JSON.stringify(body) : null, // body가 object -> null 대입
             credentials: isAuthRequire ? 'include' : 'omit',
         });

--- a/client/src/api/common/httpRequest.ts
+++ b/client/src/api/common/httpRequest.ts
@@ -4,32 +4,6 @@ import { HttpError } from './httpError';
 import type { RequestBodyOption, RequestWithoutBodyOption } from './types';
 import type { HttpMethod } from './types';
 
-const httpRequest1 = {
-    request<T>(method: HttpMethod, { ...option }: RequestBodyOption): Promise<T>{
-        const data = httpClient.createHttpRequest({
-            method,
-            ...option,
-        }).then((response) => httpClient.handleResponse<T>(response));
-        return data;
-    },
-
-    get<T>({ url, headers, isAuthRequire }: RequestWithoutBodyOption): Promise<T> {
-        return this.request('GET', { url, headers, isAuthRequire });
-    },
-    post<T>({ url, headers, body, isAuthRequire }: RequestBodyOption): Promise<T> {
-        return this.request('POST', { url, headers, body, isAuthRequire });
-    },
-    put<T>({ url, headers, body, isAuthRequire }: RequestBodyOption): Promise<T> {
-        return this.request('PUT', { url, headers, body, isAuthRequire });
-    },
-    delete<T>({ url, headers, isAuthRequire }: RequestWithoutBodyOption): Promise<T> {
-        return this.request('DELETE', { url, headers, isAuthRequire });
-    },
-    patch<T>({ url, headers, body, isAuthRequire }: RequestBodyOption): Promise<T> {
-        return this.request('PATCH', { url, headers, body, isAuthRequire });
-    },
-};
-
 const httpRequest = {
     async request<T>(
         method: HttpMethod,

--- a/client/src/api/common/httpRequest.ts
+++ b/client/src/api/common/httpRequest.ts
@@ -1,8 +1,10 @@
+import { useAuthStore } from '@stores/authStore';
 import { httpClient } from './httpClient';
+import { HttpError } from './httpError';
 import type { RequestBodyOption, RequestWithoutBodyOption } from './types';
 import type { HttpMethod } from './types';
 
-const httpRequest = {
+const httpRequest1 = {
     request<T>(method: HttpMethod, { ...option }: RequestBodyOption): Promise<T>{
         const data = httpClient.createHttpRequest({
             method,
@@ -27,5 +29,50 @@ const httpRequest = {
         return this.request('PATCH', { url, headers, body, isAuthRequire });
     },
 };
+
+const httpRequest = {
+    async request<T>(
+        method: HttpMethod,
+        option: RequestBodyOption | RequestWithoutBodyOption
+    ): Promise<T>{
+        const attempt = async (): Promise<T> => {
+            const response = await httpClient.createHttpRequest({
+                method,
+                ...option,
+            });
+            return httpClient.handleResponse<T>(response)
+        };
+
+        try{
+            return await attempt();
+        } catch (error) {
+            if(error instanceof HttpError && error.statusCode === 401){
+                //silent refresh (access Token 재발급 시도)
+                const newToken = await useAuthStore.getState().bootstrap();
+                if(newToken){
+                    //재시도
+                    return await attempt();
+                }
+            }
+            throw error;
+        }
+    },
+
+    get<T>({ url, headers, isAuthRequire }: RequestWithoutBodyOption): Promise<T> {
+        return this.request('GET', { url, headers, isAuthRequire });
+    },
+    post<T>({ url, headers, body, isAuthRequire }: RequestBodyOption): Promise<T> {
+        return this.request('POST', { url, headers, body, isAuthRequire });
+    },
+    put<T>({ url, headers, body, isAuthRequire }: RequestBodyOption): Promise<T> {
+        return this.request('PUT', { url, headers, body, isAuthRequire });
+    },
+    delete<T>({ url, headers, isAuthRequire }: RequestWithoutBodyOption): Promise<T> {
+        return this.request('DELETE', { url, headers, isAuthRequire });
+    },
+    patch<T>({ url, headers, body, isAuthRequire }: RequestBodyOption): Promise<T> {
+        return this.request('PATCH', { url, headers, body, isAuthRequire });
+    },
+}
 
 export { httpRequest };

--- a/client/src/api/common/httpRequest.ts
+++ b/client/src/api/common/httpRequest.ts
@@ -40,6 +40,7 @@ const httpRequest = {
                 method,
                 ...option,
             });
+
             return httpClient.handleResponse<T>(response)
         };
 

--- a/client/src/api/domain/auth/auth.ts
+++ b/client/src/api/domain/auth/auth.ts
@@ -2,19 +2,21 @@ import { httpRequest } from "@api/common/httpRequest";
 import { Login, LoginResponse, Register, RegisterResponse } from "./types";
 
 async function login(data: Login): Promise<LoginResponse>{
-    return httpRequest.post({
-        url: 'auth/login',
+    const response = await httpRequest.post({
+        url: 'api/v2/auth/login',
         body: data,
         isAuthRequire: false,
     })
+    return response as LoginResponse
 }
 
 async function register(data: Register): Promise<RegisterResponse>{
-    return httpRequest.post({
-        url: 'auth/register',
+    const response = await httpRequest.post({
+        url: 'api/v2/auth/register',
         body: data,
         isAuthRequire: false,
     })
+    return response as RegisterResponse;
 }
 
 export {login, register}

--- a/client/src/api/domain/auth/auth.ts
+++ b/client/src/api/domain/auth/auth.ts
@@ -3,7 +3,7 @@ import { Login, LoginResponse, Register, RegisterResponse } from "./types";
 
 async function login(data: Login): Promise<LoginResponse>{
     return httpRequest.post({
-        url: '/auth/login',
+        url: 'auth/login',
         body: data,
         isAuthRequire: false,
     })
@@ -11,7 +11,7 @@ async function login(data: Login): Promise<LoginResponse>{
 
 async function register(data: Register): Promise<RegisterResponse>{
     return httpRequest.post({
-        url: '/auth/register',
+        url: 'auth/register',
         body: data,
         isAuthRequire: false,
     })

--- a/client/src/api/domain/auth/auth.ts
+++ b/client/src/api/domain/auth/auth.ts
@@ -3,7 +3,7 @@ import { Login, LoginResponse, Register, RegisterResponse } from "./types";
 
 async function login(data: Login): Promise<LoginResponse>{
     const response = await httpRequest.post({
-        url: 'api/v2/auth/login',
+        url: 'auth/login',
         body: data,
         isAuthRequire: false,
     })
@@ -12,7 +12,7 @@ async function login(data: Login): Promise<LoginResponse>{
 
 async function register(data: Register): Promise<RegisterResponse>{
     const response = await httpRequest.post({
-        url: 'api/v2/auth/register',
+        url: 'auth/register',
         body: data,
         isAuthRequire: false,
     })

--- a/client/src/api/domain/auth/auth.ts
+++ b/client/src/api/domain/auth/auth.ts
@@ -1,0 +1,20 @@
+import { httpRequest } from "@api/common/httpRequest";
+import { Login, LoginResponse, Register, RegisterResponse } from "./types";
+
+async function login(data: Login): Promise<LoginResponse>{
+    return httpRequest.post({
+        url: '/auth/login',
+        body: data,
+        isAuthRequire: false,
+    })
+}
+
+async function register(data: Register): Promise<RegisterResponse>{
+    return httpRequest.post({
+        url: '/auth/register',
+        body: data,
+        isAuthRequire: false,
+    })
+}
+
+export {login, register}

--- a/client/src/api/domain/auth/types.ts
+++ b/client/src/api/domain/auth/types.ts
@@ -1,0 +1,18 @@
+export interface Login {
+    email: string;
+    password: string;
+}
+
+export interface Register {
+    email: string;
+    name: string;
+    password: string;
+}
+
+export interface LoginResponse {
+    accessToken: string;
+}
+
+export interface RegisterResponse {
+    message: string;
+}

--- a/client/src/api/domain/index.ts
+++ b/client/src/api/domain/index.ts
@@ -1,1 +1,2 @@
 export * from './club/club';
+export * from './auth/auth';

--- a/client/src/api/domain/myClub/myClub.ts
+++ b/client/src/api/domain/myClub/myClub.ts
@@ -3,7 +3,7 @@ import { MyClubResponse } from "./types";
 
 async function getMyClub(): Promise<MyClubResponse[]>{
     const response = await httpRequest.get({
-        url: 'api/v2/clubs/my',
+        url: 'clubs/my',
         isAuthRequire: true,
     })
     return response as MyClubResponse[];

--- a/client/src/api/domain/myClub/myClub.ts
+++ b/client/src/api/domain/myClub/myClub.ts
@@ -1,0 +1,12 @@
+import { httpRequest } from "@api/common/httpRequest";
+import { MyClubResponse } from "./types";
+
+async function getMyClub(): Promise<MyClubResponse[]>{
+    const response = await httpRequest.get({
+        url: 'api/v2/clubs/my',
+        isAuthRequire: true,
+    })
+    return response as MyClubResponse[];
+}
+
+export {getMyClub}

--- a/client/src/api/domain/myClub/types.ts
+++ b/client/src/api/domain/myClub/types.ts
@@ -1,0 +1,7 @@
+export interface MyClubResponse {
+    id: string;
+    name: string;
+    shortDescription: string;
+    imageUrl: string;
+    thumbnailUrl: string;
+}

--- a/client/src/api/queryFactory/myClubQueries.ts
+++ b/client/src/api/queryFactory/myClubQueries.ts
@@ -1,0 +1,15 @@
+import { getMyClub } from "@api/domain/myClub/myClub"
+import { myClubKeys } from "@api/querykeyFactory"
+import { DEFAULT_STALETIME } from "@constants/staleTime"
+import { queryOptions } from "@tanstack/react-query"
+
+const myClubQueries = {
+    all: () => 
+        queryOptions({
+            queryKey: myClubKeys.all,
+            queryFn: () => getMyClub(),
+            staleTime: DEFAULT_STALETIME,
+        }),  
+}
+
+export {myClubQueries}

--- a/client/src/api/querykeyFactory.ts
+++ b/client/src/api/querykeyFactory.ts
@@ -28,4 +28,8 @@ const clubKeys = {
     detail: (id: string) => ['detail', id] as const,
 };
 
-export { clubKeys };
+const myClubKeys = {
+  all: ['clubs'] as const,
+}
+
+export { clubKeys, myClubKeys };

--- a/client/src/components/QuestionForm/QuestionForm.tsx
+++ b/client/src/components/QuestionForm/QuestionForm.tsx
@@ -11,9 +11,7 @@ import {
     s_questionOptionRow,
     s_removeOptionButton,
 } from './QuestionForm.style';
-import { CheckboxRoot } from '@components/Checkbox/CheckboxRoot';
-import { CheckboxHiddenInput } from '@components/Checkbox/CheckboxHiddenInput';
-import { CheckboxControl } from '@components/Checkbox/CheckboxControl';
+import { Checkbox } from '@components';
 import { useToast } from '@hooks/useToast';
 
 function QuestionForm({ question, updateQuestion }: QuestionFormProps) {
@@ -113,10 +111,10 @@ function QuestionForm({ question, updateQuestion }: QuestionFormProps) {
                 {question.options?.map((option) => (
                     <div key={option.id} css={s_questionOptionRow}>
                         {question.type === 'multiple' ? (
-                            <CheckboxRoot disabled size="md">
-                                <CheckboxHiddenInput />
-                                <CheckboxControl />
-                            </CheckboxRoot>
+                            <Checkbox.Root disabled size="md">
+                                <Checkbox.HiddenInput />
+                                <Checkbox.Control />
+                            </Checkbox.Root>
                         ) : (
                             <div />
                         )}

--- a/client/src/constants/api.ts
+++ b/client/src/constants/api.ts
@@ -1,1 +1,1 @@
-export const BASE_URL = `${process.env.BASE_URL}`;
+export const BASE_URL = process.env.BASE_URL;

--- a/client/src/constants/api.ts
+++ b/client/src/constants/api.ts
@@ -1,1 +1,1 @@
-export const BASE_URL = process.env.BASE_URL;
+export const BASE_URL = `${process.env.BASE_URL}/api/v2/`;

--- a/client/src/constants/api.ts
+++ b/client/src/constants/api.ts
@@ -1,1 +1,1 @@
-export const BASE_URL = `${process.env.BASE_URL}/api/v2/`;
+export const BASE_URL = `${process.env.BASE_URL}`;

--- a/client/src/constants/staleTime.ts
+++ b/client/src/constants/staleTime.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_STALETIME = 1000 * 20;

--- a/client/src/hooks/useLogin.tsx
+++ b/client/src/hooks/useLogin.tsx
@@ -1,0 +1,20 @@
+import { login } from "@api/domain";
+import { Login, LoginResponse } from "@api/domain/auth/types";
+import { useAuthStore } from "@stores/authStore";
+import { useMutation } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
+
+function useLogin() {
+    const setAccessToken = useAuthStore((state) => state.setAccessToken);
+    const navigate = useNavigate();
+
+    return useMutation<LoginResponse, Error, Login>({
+        mutationFn: login,
+        onSuccess: (data) => {
+            setAccessToken(data.accessToken);
+            navigate('/myClub', {replace: true})
+        }
+    })
+}
+
+export {useLogin}

--- a/client/src/hooks/useLogin.tsx
+++ b/client/src/hooks/useLogin.tsx
@@ -3,16 +3,18 @@ import { Login, LoginResponse } from "@api/domain/auth/types";
 import { useAuthStore } from "@stores/authStore";
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
+import { useRouter } from "./useRouter";
 
 function useLogin() {
     const setAccessToken = useAuthStore((state) => state.setAccessToken);
-    const navigate = useNavigate();
+    const { removeHistoryAndGo } = useRouter();
 
     return useMutation<LoginResponse, Error, Login>({
         mutationFn: login,
         onSuccess: (data) => {
             setAccessToken(data.accessToken);
-            navigate('/myClub', {replace: true})
+            console.log(data.accessToken);
+            removeHistoryAndGo('/myClub');
         }
     })
 }

--- a/client/src/hooks/useLogin.tsx
+++ b/client/src/hooks/useLogin.tsx
@@ -13,8 +13,10 @@ function useLogin() {
         mutationFn: login,
         onSuccess: (data) => {
             setAccessToken(data.accessToken);
-            console.log(data.accessToken);
             removeHistoryAndGo('/myClub');
+        },
+        onError: (error) => {
+            console.log(error);
         }
     })
 }

--- a/client/src/hooks/useRegister.tsx
+++ b/client/src/hooks/useRegister.tsx
@@ -10,6 +10,9 @@ function useRegister(){
         mutationFn: register,
         onSuccess: () => {
             navigate('/login', {replace: true})
+        },
+        onError: (error) => {
+            console.log(error)
         }
     })
 }

--- a/client/src/hooks/useRegister.tsx
+++ b/client/src/hooks/useRegister.tsx
@@ -1,0 +1,17 @@
+import { register } from "@api/domain";
+import { Register, RegisterResponse } from "@api/domain/auth/types";
+import { useMutation } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
+
+function useRegister(){
+    const navigate = useNavigate();
+
+    return useMutation<RegisterResponse, Error, Register>({
+        mutationFn: register,
+        onSuccess: () => {
+            navigate('/login', {replace: true})
+        }
+    })
+}
+
+export {useRegister}

--- a/client/src/pages/AuthPage/LoginPage/LoginPage.tsx
+++ b/client/src/pages/AuthPage/LoginPage/LoginPage.tsx
@@ -50,8 +50,8 @@ function LoginPage() {
                 )}
 
                 <div css={buttonContainer}>
-                    <Button variant="primary" size="full" type='submit'>
-                        {isPending ? '로딩 중...' : '로그인'}
+                    <Button variant="primary" size="full" type='submit' loading={isPending}>
+                        로그인
                     </Button>
                     <Button
                         onClick={() => removeHistoryAndGo('/register')}

--- a/client/src/pages/AuthPage/LoginPage/LoginPage.tsx
+++ b/client/src/pages/AuthPage/LoginPage/LoginPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FormEvent, useState } from 'react';
 import {
     LoginContainer,
     LoginBox,
@@ -11,23 +11,36 @@ import { PasswordInput } from '@components/PasswordInput';
 import { css } from '@emotion/react';
 import theme from '@styles/theme';
 import { useRouter } from '@hooks/useRouter';
+import { useLogin } from '@hooks/useLogin';
 
 function LoginPage() {
+    const [email, setEmail] = useState('');
+    const [password, setPassword] = useState('');
+    const {mutate: login, isPending, error} = useLogin();
     const { removeHistoryAndGo } = useRouter();
 
+    const handleSubmit = (e: FormEvent) => {
+        e.preventDefault();
+        login({email, password})
+    }
+
     return (
-        <div css={LoginContainer}>
+        <form css={LoginContainer} onSubmit={handleSubmit}>
             <div css={LoginBox}>
                 <h1 css={titleContainer}>로그인</h1>
 
                 <div css={inputContainer}>
-                    <Input placeholder="이메일" height={'4.5rem'} />
-                    <PasswordInput placeholder="비밀번호" height={'4.5rem'} />
+                    <Input value={email} onChange={(e) => setEmail(e.target.value)} placeholder="이메일" height={'4.5rem'} />
+                    <PasswordInput value={password} onChange={(e) => setPassword(e.target.value)} placeholder="비밀번호" height={'4.5rem'} />
                 </div>
 
+                {error && (
+                    <div>로그인 실패</div>
+                )}
+
                 <div css={buttonContainer}>
-                    <Button variant="primary" size="full">
-                        로그인
+                    <Button variant="primary" size="full" type='submit'>
+                        {isPending ? '로딩 중...' : '로그인'}
                     </Button>
                     <Button
                         onClick={() => removeHistoryAndGo('/register')}
@@ -38,7 +51,7 @@ function LoginPage() {
                     </Button>
                 </div>
             </div>
-        </div>
+        </form>
     );
 }
 export { LoginPage };

--- a/client/src/pages/AuthPage/LoginPage/LoginPage.tsx
+++ b/client/src/pages/AuthPage/LoginPage/LoginPage.tsx
@@ -14,15 +14,28 @@ import { useRouter } from '@hooks/useRouter';
 import { useLogin } from '@hooks/useLogin';
 
 function LoginPage() {
-    const [email, setEmail] = useState('');
-    const [password, setPassword] = useState('');
-    const {mutate: login, isPending, error} = useLogin();
+    // prop destruction
+    // lib hooks
     const { removeHistoryAndGo } = useRouter();
+    // initial values
+    // state, ref, querystring hooks
+     const [email, setEmail] = useState('');
+    const [password, setPassword] = useState('');
 
-    const handleSubmit = (e: FormEvent) => {
+    // form hooks
+    // query hooks
+    const {mutate: login, isPending, error} = useLogin();
+
+    // calculated values
+    // handlers
+     const handleSubmit = (e: FormEvent) => {
         e.preventDefault();
         login({email, password})
     }
+    // effects
+   
+    
+    
 
     return (
         <form css={LoginContainer} onSubmit={handleSubmit}>

--- a/client/src/pages/AuthPage/LoginPage/LoginPage.tsx
+++ b/client/src/pages/AuthPage/LoginPage/LoginPage.tsx
@@ -17,9 +17,10 @@ function LoginPage() {
     // prop destruction
     // lib hooks
     const { removeHistoryAndGo } = useRouter();
+    
     // initial values
     // state, ref, querystring hooks
-     const [email, setEmail] = useState('');
+    const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
 
     // form hooks
@@ -33,9 +34,6 @@ function LoginPage() {
         login({email, password})
     }
     // effects
-   
-    
-    
 
     return (
         <form css={LoginContainer} onSubmit={handleSubmit}>

--- a/client/src/pages/AuthPage/RegisterPage/RegisterPage.tsx
+++ b/client/src/pages/AuthPage/RegisterPage/RegisterPage.tsx
@@ -77,8 +77,8 @@ function RegisterPage() {
                 )}
 
                 <div css={buttonContainer}>
-                    <Button type='submit' variant="primary" size="full">
-                        {isPending ? '로딩 중...' : '회원가입'}
+                    <Button type='submit' variant="primary" size="full" loading={isPending}>
+                        회원가입
                     </Button>
                     <Button
                         onClick={() => removeHistoryAndGo('/login')}

--- a/client/src/pages/AuthPage/RegisterPage/RegisterPage.tsx
+++ b/client/src/pages/AuthPage/RegisterPage/RegisterPage.tsx
@@ -15,14 +15,24 @@ import { useRegister } from '@hooks/useRegister';
 import { useToast } from '@hooks/useToast';
 
 function RegisterPage() {
+    // prop destruction
+    // lib hooks
+    const { removeHistoryAndGo } = useRouter();
+    const {toast} = useToast();
+
+    // initial values
+    // state, ref, querystring hooks
     const [email, setEmail] = useState('');
     const [name, setName] = useState('');
     const [password, setPassword] = useState('');
     const [passwordConfirm, setPasswordConfirm] = useState('');
-    const {mutate: register, isPending, error} = useRegister();
-    const {toast} = useToast();
-    const { removeHistoryAndGo } = useRouter();
 
+    // form hooks
+    // query hooks
+    const {mutate: register, isPending, error} = useRegister();
+
+    // calculated values
+    // handlers
     const handleSubmit = (event: FormEvent) => {
         event.preventDefault();
         if(password !== passwordConfirm){
@@ -35,6 +45,8 @@ function RegisterPage() {
         register({email, name, password});
     }
 
+    // effects
+    
     return (
         <form css={RegisterContainer} onSubmit={handleSubmit}>
             <div css={RegisterBox}>

--- a/client/src/pages/AuthPage/RegisterPage/RegisterPage.tsx
+++ b/client/src/pages/AuthPage/RegisterPage/RegisterPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FormEvent, useState } from 'react';
 import {
     RegisterContainer,
     RegisterBox,
@@ -11,18 +11,38 @@ import { Input, Button } from '@components/_common';
 import { PasswordInput } from '@components/PasswordInput';
 import { css } from '@emotion/react';
 import { useRouter } from '@hooks/useRouter';
+import { useRegister } from '@hooks/useRegister';
+import { useToast } from '@hooks/useToast';
 
 function RegisterPage() {
+    const [email, setEmail] = useState('');
+    const [name, setName] = useState('');
+    const [password, setPassword] = useState('');
+    const [passwordConfirm, setPasswordConfirm] = useState('');
+    const {mutate: register, isPending, error} = useRegister();
+    const {toast} = useToast();
     const { removeHistoryAndGo } = useRouter();
 
+    const handleSubmit = (event: FormEvent) => {
+        event.preventDefault();
+        if(password !== passwordConfirm){
+            toast.error('비밀번호가 일치하지 않습니다.', {
+                toastTheme: 'black',
+                position: 'topCenter',
+            });
+            return;
+        }
+        register({email, name, password});
+    }
+
     return (
-        <div css={RegisterContainer}>
+        <form css={RegisterContainer} onSubmit={handleSubmit}>
             <div css={RegisterBox}>
                 <h1 css={titleContainer}>회원가입</h1>
 
                 <div css={inputContainer}>
                     <div css={emailContainer}>
-                        <Input placeholder="test@naver.com" height={'4.5rem'} label={'이메일'} />
+                        <Input value={email} onChange={(e) => setEmail(e.target.value)} placeholder="test@naver.com" height={'4.5rem'} label={'이메일'} />
                         <Button
                             variant="primary"
                             size="full"
@@ -35,14 +55,18 @@ function RegisterPage() {
                             중복확인
                         </Button>
                     </div>
-                    <Input placeholder="홍길동" height={'4.5rem'} label={'이름'} />
-                    <PasswordInput placeholder="••••••" height={'4.5rem'} label={'비밀번호'} />
-                    <PasswordInput placeholder="••••••" height={'4.5rem'} label={'비밀번호확인'} />
+                    <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="홍길동" height={'4.5rem'} label={'이름'} />
+                    <PasswordInput value={password} onChange={(e) => setPassword(e.target.value)} placeholder="••••••" height={'4.5rem'} label={'비밀번호'} />
+                    <PasswordInput value={passwordConfirm} onChange={(e) => setPasswordConfirm(e.target.value)} placeholder="••••••" height={'4.5rem'} label={'비밀번호확인'} />
                 </div>
 
+                {error && (
+                    <div>회원가입에 실패했습니다.</div>
+                )}
+
                 <div css={buttonContainer}>
-                    <Button variant="primary" size="full">
-                        회원가입
+                    <Button type='submit' variant="primary" size="full">
+                        {isPending ? '로딩 중...' : '회원가입'}
                     </Button>
                     <Button
                         onClick={() => removeHistoryAndGo('/login')}
@@ -53,7 +77,7 @@ function RegisterPage() {
                     </Button>
                 </div>
             </div>
-        </div>
+        </form>
     );
 }
 export { RegisterPage };

--- a/client/src/pages/ClubApplyPage/PersonalInfoPage/ClubApplyPersonalInfoPage.tsx
+++ b/client/src/pages/ClubApplyPage/PersonalInfoPage/ClubApplyPersonalInfoPage.tsx
@@ -12,9 +12,6 @@ import {
     labelContainer,
     labelSx,
 } from './ClubApplyPersonalInfoPage.style';
-import type { ClubApplyPersonalInfoPageProps } from '../types';
-import { getAnswer } from '../utils';
-import { Checkbox } from '@components';
 
 function ClubApplyPersonalInfoPage({
     answers,

--- a/client/src/pages/MyClubPage/MyClubPage.tsx
+++ b/client/src/pages/MyClubPage/MyClubPage.tsx
@@ -13,9 +13,11 @@ import ChevronRight from '@assets/images/chevronRight.svg';
 import { myClubQueries } from '@api/queryFactory/myClubQueries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 
-
 function MyClubPage() {
+
+    //query hooks
     const {data: myClubs} = useSuspenseQuery(myClubQueries.all());
+
     return (
         <div css={myClubPageLayout}>
             <div css={myClubPageContainer}>

--- a/client/src/pages/MyClubPage/MyClubPage.tsx
+++ b/client/src/pages/MyClubPage/MyClubPage.tsx
@@ -10,35 +10,12 @@ import {
 } from './MyClubPage.style';
 import { Text, Avatar, Button } from '@components';
 import ChevronRight from '@assets/images/chevronRight.svg';
+import { myClubQueries } from '@api/queryFactory/myClubQueries';
+import { useSuspenseQuery } from '@tanstack/react-query';
 
-const myClubs = [
-    {
-        id: 1, // 고유 ID는 key prop으로 사용하기에 가장 좋습니다.
-        name: 'En#(엔샵)',
-        description: '세종대학교 SW개발동아리 En#입니다.',
-        avatarSrc: 'https://example.com/avatar_en_sharp.png', // 실제 이미지 경로
-    },
-    {
-        id: 2,
-        name: 'CCC',
-        description: '아름다운 대학 생활을 만드는 기독교 동아리 CCC입니다.',
-        avatarSrc: 'https://example.com/avatar_ccc.png', // 실제 이미지 경로
-    },
-    {
-        id: 3,
-        name: '비상구',
-        description: '세종대학교 중앙 연극 동아리 비상구입니다.',
-        avatarSrc: 'https://example.com/avatar_bisanggu.png',
-    },
-    {
-        id: 4,
-        name: '비상구',
-        description: '세종대학교 중앙 연극 동아리 비상구입니다.',
-        avatarSrc: 'https://example.com/avatar_bisanggu.png',
-    },
-];
 
 function MyClubPage() {
+    const {data: myClubs} = useSuspenseQuery(myClubQueries.all());
     return (
         <div css={myClubPageLayout}>
             <div css={myClubPageContainer}>
@@ -49,7 +26,7 @@ function MyClubPage() {
                     {myClubs.map((club) => (
                         <li key={club.id}>
                             <Button variant="transparent" size="xl" sx={clubItem}>
-                                <Avatar radius="10px" />
+                                <Avatar radius="10px" imageURL={club.imageUrl}/>
                                 <div css={clubItemText}>
                                     <Text textAlign="start">{club.name}</Text>
                                     <Text
@@ -59,7 +36,7 @@ function MyClubPage() {
                                         noWrap
                                         cropped
                                     >
-                                        {club.description}
+                                        {club.shortDescription}
                                     </Text>
                                 </div>
                                 <ChevronRight width="25" height="25" strokeWidth={2} />

--- a/client/src/pages/RecruitCreatePage/RecruitCreatePage.tsx
+++ b/client/src/pages/RecruitCreatePage/RecruitCreatePage.tsx
@@ -75,6 +75,7 @@ function RecruitCreatePage() {
         containerRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
     }, [activeStep]);
 
+    //FIX: 따로 컴포넌트로 빼기
     const stepComponent = (step: number) => {
         switch (step) {
             case 0:

--- a/client/src/stores/authStore.ts
+++ b/client/src/stores/authStore.ts
@@ -14,7 +14,7 @@ export const useAuthStore = create<AuthState>((set) => ({
     clear: () => set({accessToken: null}),
     bootstrap: async() => {
         try{
-            const refreshURL = new URL('/auth/refreshToken', BASE_URL).toString();
+            const refreshURL = new URL('api/v2/auth/refreshToken', BASE_URL).toString();
             const res = await fetch(refreshURL, {
                 method: 'GET',
                 credentials: 'include'

--- a/client/src/stores/authStore.ts
+++ b/client/src/stores/authStore.ts
@@ -15,12 +15,12 @@ export const useAuthStore = create<AuthState>((set) => ({
     bootstrap: async() => {
         try{
             const refreshURL = new URL('api/v2/auth/refreshToken', BASE_URL).toString();
-            const res = await fetch(refreshURL, {
+            const response = await fetch(refreshURL, {
                 method: 'GET',
                 credentials: 'include'
             });
-            if(!res.ok) throw new Error('refresh 실패');
-            const {accessToken} = (await res.json()) as {accessToken: string}
+            if(!response.ok) throw new Error('refresh 실패');
+            const {accessToken} = (await response.json()) as {accessToken: string}
             set({accessToken})
             return accessToken;
         } catch {

--- a/client/src/stores/authStore.ts
+++ b/client/src/stores/authStore.ts
@@ -1,0 +1,27 @@
+import { create } from "zustand";
+
+interface AuthState {
+    accessToken: string | null;
+    setAccessToken: (t: string | null) => void;
+    clear: () => void;
+    bootstrap: () => Promise<void>;
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+    accessToken: null,
+    setAccessToken: (token) => set({accessToken: token}),
+    clear: () => set({accessToken: null}),
+    bootstrap: async() => {
+        try{
+            const res = await fetch('/auth/refreshToken', {
+                method: 'GET',
+                credentials: 'include'
+            });
+            if(!res.ok) throw new Error();
+            const {accessToken} = (await res.json()) as {accessToken: string}
+            set({accessToken})
+        } catch {
+            set({accessToken: null})
+        }
+    }
+}))

--- a/client/src/stores/authStore.ts
+++ b/client/src/stores/authStore.ts
@@ -1,10 +1,11 @@
+import { BASE_URL } from "@constants/api";
 import { create } from "zustand";
 
 interface AuthState {
     accessToken: string | null;
-    setAccessToken: (t: string | null) => void;
+    setAccessToken: (token: string | null) => void;
     clear: () => void;
-    bootstrap: () => Promise<void>;
+    bootstrap: () => Promise<string | null>;
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
@@ -13,15 +14,18 @@ export const useAuthStore = create<AuthState>((set) => ({
     clear: () => set({accessToken: null}),
     bootstrap: async() => {
         try{
-            const res = await fetch('/auth/refreshToken', {
+            const refreshURL = new URL('/auth/refreshToken', BASE_URL).toString();
+            const res = await fetch(refreshURL, {
                 method: 'GET',
                 credentials: 'include'
             });
-            if(!res.ok) throw new Error();
+            if(!res.ok) throw new Error('refresh 실패');
             const {accessToken} = (await res.json()) as {accessToken: string}
             set({accessToken})
+            return accessToken;
         } catch {
             set({accessToken: null})
+            return null;
         }
     }
 }))

--- a/client/src/stores/index.ts
+++ b/client/src/stores/index.ts
@@ -1,0 +1,1 @@
+export * from './authStore';

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -31,6 +31,7 @@
             "@styles/*": ["styles/*"],
             "@hooks/*": ["hooks/*"],
             "@contexts/*": ["contexts/*"],
+            "@stores/*": ["stores/*"],
             "@api/*": ["api/*"]
         }
     },

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2765,7 +2765,7 @@
   resolved "https://registry.yarnpkg.com/@types/statuses/-/statuses-2.0.5.tgz#f61ab46d5352fd73c863a1ea4e1cef3b0b51ae63"
   integrity sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==
 
-"@types/tough-cookie@^4.0.5":
+"@types/tough-cookie@*", "@types/tough-cookie@^4.0.5":
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.5.tgz#cb6e2a691b70cb177c6e3ae9c1d2e8b2ea8cd304"
   integrity sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==
@@ -8661,7 +8661,7 @@ toidentifier@1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
-tough-cookie@^4.1.4:
+tough-cookie@^4.1.2, tough-cookie@^4.1.4:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.4.tgz#945f1461b45b5a8c76821c33ea49c3ac192c1b36"
   integrity sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==
@@ -9345,3 +9345,8 @@ yoctocolors-cjs@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz#f4b905a840a37506813a7acaa28febe97767a242"
   integrity sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==
+
+zustand@^5.0.6:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-5.0.6.tgz#a2da43d8dc3d31e314279e5baec06297bea70a5c"
+  integrity sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A==


### PR DESCRIPTION
## 📌 관련 이슈
closed #260 

## 🛠️ 작업 내용
- [ ] AccessToken(AT) 및 RefreshToken(RT) 구조 및 흐름 설계
- [ ] AT 메모리 상태 관리 로직 구현 (zustand 도입)
- [ ] `httpClient` 에 AT 삽입 및 401 처리 로직 구현

## 🎯 리뷰 포인트

### 주요 변경 사항
|파일 위치|변경 내용|
|------|---|
|src/api/common/httpClient.ts|Header  토큰 삽입 방식 변경 및 AccessToken 관련 로직 추가|
|src/api/common/httpRequest.ts|401에러 감지 후 silent-refresh 및 재시도 로직 추가|
|src/stores/authStore.ts|zustand 메모리 관리할 폴더 stores 추가 후 AT관련 저장 로직 적용 + bootstrap()속성 적용|

### 상세 내용

|인증 인가 시퀀스|
|:---:|
|<img width="9633" height="9937" alt="image" src="https://github.com/user-attachments/assets/5bb572fa-ce8b-4a33-b676-9ec6cc5097f6" />|
|위 시퀀스를 기반으로 AT 및 RT 관련 인증인가 구현|

- 브라우저에서의 접근을 최대한 막기 위해 AT는 메모리에서 관리하고, RT는 HTTP-only 쿠키로 관리하기로 했습니다.

- 기존 코드에서 Header 토큰 삽입 방식 변경
```
const authHeaders: Record<string, string> = {
  'Content-Type': 'application/json',
  ...headers, 
};

if (accessToken && isAuthRequire) {
  authHeaders['Authorization'] = `Bearer ${accessToken}`;
}
```
`httpClient.ts`의 `createHttpRequest()`함수 내 토큰 삽입을 위해 위와 같은 로직을 작성하였으나, headers와의 타입 오류로 인해 스프레드 연산자를 이용한 토큰 삽입에서 에러가 발생하였습니다.
위 트러블 이슈를 해결하기 위한 대표적인 방식 두 가지 중

1. normalizeHeaders함수를 통해 HeaderInit to Recrod<string, string>으로 convert 
2. Headers 객체로 일원화

mdn 에서 권장하는 방식은 Headers 객체를 활용한다는 문서에 의거해 2번 방식으로 리펙토링하기로 결정했습니다. 

기존의 방식에서 새로운 Headers 객체를 생성 후 
```
 // ✅ Headers 객체로 일원화 처리
  const authHeaders = new Headers(headers);

  authHeaders.set('Content-Type', 'application/json');

  if (accessToken && isAuthRequire) {
    authHeaders.set('Authorization', `Bearer ${accessToken}`);
  }
```

토큰을 삽입하는 방식으로 해결했습니다.

추가적으로

- 기존 httpRequest() 함수에 silent-refresh 로직 추가
- queryFactory hook -> staleTime 추가 (최소 캐싱 시간 20초로 설정)
- AT를 zustand를 활용해 메모리에 저장하기 때문에, 페이지를 새로고침 시 해당 토큰은 삭제되게 됩니다. UX 개선을 위해, 페이지 새로고침 시 AT를 서버에서 다시 받아올 수 있도록 bootstrap() 속성을 추가했습니다. 해당 속성 사용 시 refreshToken을 기반으로 저장된 accessToken을 다시 받아올 수 있도록 했습니다.

### 유의사항
현재 프론트 도메인과 서버 도메인이 일치하지 않아, refreshToken을 활용한 accessToken 갱신 작업은 502 오류가 발생합니다.
새로고침 시 에러가 터지는 부분은 이후 도메인을 일치시킨 후에 다시 실행해보고 오류가 있다면 그때 다시 수정해보도록 하겠습니다!

token 이 필요한 api 를 요청하실 때는 `isAuthRequire: true`를 설정하면 자동으로 헤더에 담기도록 설정해놓은 상태입니다!

### 참고 링크
https://tanstack.com/query/latest/docs/framework/react/guides/caching
https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch
https://developer.mozilla.org/en-US/docs/Web/API/Headers

## ⏳ 작업 시간
추정 시간:  2일
실제 시간:   4일

레퍼런스를 다양하게 찾아보느라 추정 시간을 오래 잡았는데, 구현 후에도 각종 CORS나 서버와의 통신오류를 해결하느라 시간이 조금 더 걸린 것 같습니다.