### PR TITLE
[BE] Application 도메인 API 구현

### DIFF
--- a/server/src/main/java/com/ryc/api/v2/announcement/domain/vo/AnnouncementPeriodInfo.java
+++ b/server/src/main/java/com/ryc/api/v2/announcement/domain/vo/AnnouncementPeriodInfo.java
@@ -42,7 +42,7 @@ public record AnnouncementPeriodInfo(
    */
   public void validate(boolean hasInterview) {
 
-    // 1. 면접 진행 시 추가되는 기간 값들에 대한 validate
+    // 1. 면접 진행 시 추가되는 기간 값들에 대한 checkBusinessRules
     if (hasInterview) {
       if (interviewPeriod == null) {
         throw new BusinessRuleException(AnnouncementErrorCode.INTERVIEW_PERIOD_REQUIRED);
@@ -59,7 +59,7 @@ public record AnnouncementPeriodInfo(
       }
     }
 
-    // 2. 기간들간의 validate
+    // 2. 기간들간의 checkBusinessRules
     validateSequence(hasInterview);
   }
 

--- a/server/src/main/java/com/ryc/api/v2/announcement/domain/vo/Period.java
+++ b/server/src/main/java/com/ryc/api/v2/announcement/domain/vo/Period.java
@@ -25,13 +25,13 @@ public record Period(LocalDateTime startDate, LocalDateTime endDate) {
             .endDate(periodRequest.endDate())
             .build();
 
-    // 3. validate
+    // 3. checkBusinessRules
     period.validate();
     return period;
   }
 
   /**
-   * 기간 validate
+   * 기간 checkBusinessRules
    *
    * @throws IllegalArgumentException 시작날짜보다 끝 날짜가 빠른 경우
    */

--- a/server/src/main/java/com/ryc/api/v2/announcement/service/AnnouncementService.java
+++ b/server/src/main/java/com/ryc/api/v2/announcement/service/AnnouncementService.java
@@ -19,10 +19,8 @@ import com.ryc.api.v2.announcement.presentation.dto.response.AnnouncementGetDeta
 import com.ryc.api.v2.announcement.presentation.dto.response.AnnouncementUpdateResponse;
 import com.ryc.api.v2.club.infra.jpa.ClubJpaRepository;
 import com.ryc.api.v2.club.service.ClubService;
-import com.ryc.api.v2.common.aop.annotation.HasRole;
 import com.ryc.api.v2.common.aop.annotation.ValidClub;
 import com.ryc.api.v2.common.aop.dto.ClubRoleSecuredDto;
-import com.ryc.api.v2.role.domain.enums.Role;
 
 import lombok.RequiredArgsConstructor;
 
@@ -34,7 +32,6 @@ public class AnnouncementService {
   private final ClubJpaRepository clubJpaRepository;
 
   @Transactional
-  @HasRole(Role.MEMBER)
   public AnnouncementCreateResponse createAnnouncement(
       ClubRoleSecuredDto clubRoleSecuredDto, AnnouncementCreateRequest request) {
     // 1.Club 찾기
@@ -68,7 +65,6 @@ public class AnnouncementService {
   }
 
   @Transactional
-  @HasRole(Role.MEMBER)
   public AnnouncementUpdateResponse updateAnnouncement(
       ClubRoleSecuredDto clubRoleSecuredDto,
       AnnouncementUpdateRequest request,

--- a/server/src/main/java/com/ryc/api/v2/applicant/domain/Applicant.java
+++ b/server/src/main/java/com/ryc/api/v2/applicant/domain/Applicant.java
@@ -1,19 +1,73 @@
 package com.ryc.api.v2.applicant.domain;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import com.ryc.api.v2.applicant.domain.enums.ApplicantStatus;
+import com.ryc.api.v2.applicant.presentation.dto.request.ApplicantCreateRequest;
+import com.ryc.api.v2.application.common.exception.code.ApplicationCreateErrorCode;
+import com.ryc.api.v2.applicationForm.domain.ApplicationForm;
+import com.ryc.api.v2.applicationForm.domain.enums.PersonalInfoQuestionType;
+import com.ryc.api.v2.common.constant.DomainDefaultValues;
+import com.ryc.api.v2.common.exception.custom.BusinessRuleException;
+
 import lombok.Builder;
 import lombok.Getter;
-
-import java.time.LocalDateTime;
 
 @Getter
 @Builder
 public class Applicant {
-    private final String id;
-    private final String userId;
-    private final String announcementId;
-    private final ApplicantStatus status;
-    private final Boolean isDeleted;
-    private final String name;
-    private final String email;
+  private final String id;
+  private final String announcementId;
+
+  // 개인 필수 정보
+  private final String email;
+  private final String name;
+  private final ApplicantStatus status;
+  private final Boolean isDeleted;
+  // 이름, 이메일 제외 개인정보 질문 저장
+  private final List<ApplicantPersonalInfo> personalInfos;
+
+  public static Applicant initialize(ApplicantCreateRequest request, String announcementId) {
+    List<ApplicantPersonalInfo> personalInfos =
+        request.personalInfos().stream().map(ApplicantPersonalInfo::initialize).toList();
+
+    return Applicant.builder()
+        .name(request.name())
+        .announcementId(announcementId)
+        .email(request.email())
+        .id(DomainDefaultValues.DEFAULT_INITIAL_ID)
+        .personalInfos(personalInfos)
+        .status(ApplicantStatus.PENDING)
+        .isDeleted(false)
+        .build();
+  }
+
+  public void checkBusinessRules(ApplicationForm applicationForm) {
+    Set<PersonalInfoQuestionType> requiredTypes =
+        applicationForm.getPersonalInfoQuestionTypes().stream()
+            .filter(
+                type ->
+                    type != PersonalInfoQuestionType.NAME && type != PersonalInfoQuestionType.EMAIL)
+            .collect(Collectors.toSet());
+
+    Set<PersonalInfoQuestionType> providedTypes =
+        personalInfos.stream()
+            .map(ApplicantPersonalInfo::getQuestionType)
+            .collect(Collectors.toCollection(HashSet::new));
+
+    if (!providedTypes.containsAll(requiredTypes)) {
+      throw new BusinessRuleException(
+          ApplicationCreateErrorCode.MISSING_REQUIRED_PERSONAL_INFO_ANSWER);
+    }
+
+    for (ApplicantPersonalInfo personalInfo : personalInfos) {
+      if (personalInfo.getQuestionType() == PersonalInfoQuestionType.NAME
+          || personalInfo.getQuestionType() == PersonalInfoQuestionType.EMAIL) {
+        throw new BusinessRuleException(ApplicationCreateErrorCode.DUPLICATE_PERSONAL_INFO_ANSWER);
+      }
+    }
+  }
 }

--- a/server/src/main/java/com/ryc/api/v2/applicant/domain/ApplicantPersonalInfo.java
+++ b/server/src/main/java/com/ryc/api/v2/applicant/domain/ApplicantPersonalInfo.java
@@ -1,0 +1,24 @@
+package com.ryc.api.v2.applicant.domain;
+
+import com.ryc.api.v2.applicant.presentation.dto.request.ApplicantPersonalInfoCreateRequest;
+import com.ryc.api.v2.applicationForm.domain.enums.PersonalInfoQuestionType;
+import com.ryc.api.v2.common.constant.DomainDefaultValues;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ApplicantPersonalInfo {
+  private final String id;
+  private final PersonalInfoQuestionType questionType;
+  private final String value;
+
+  public static ApplicantPersonalInfo initialize(ApplicantPersonalInfoCreateRequest request) {
+    return ApplicantPersonalInfo.builder()
+        .id(DomainDefaultValues.DEFAULT_INITIAL_ID)
+        .questionType(request.personalInfoQuestionType())
+        .value(request.value())
+        .build();
+  }
+}

--- a/server/src/main/java/com/ryc/api/v2/applicant/domain/ApplicantRepository.java
+++ b/server/src/main/java/com/ryc/api/v2/applicant/domain/ApplicantRepository.java
@@ -3,8 +3,14 @@ package com.ryc.api.v2.applicant.domain;
 import java.util.List;
 import java.util.Optional;
 
+import com.ryc.api.v2.applicant.domain.enums.ApplicantStatus;
+
 public interface ApplicantRepository {
-    Applicant save(Applicant applicant);
-    Optional<Applicant> findById(String id);
-    List<Applicant> findAllByAnnouncementId(String announcementId);
+  Applicant save(Applicant applicant);
+
+  Applicant findById(String id);
+
+  List<Applicant> findAllByAnnouncementId(String announcementId);
+
+  List<Applicant> findAllByAnnouncementIdAndStatus(String announcementId, ApplicantStatus status);
 }

--- a/server/src/main/java/com/ryc/api/v2/applicant/domain/ApplicantRepository.java
+++ b/server/src/main/java/com/ryc/api/v2/applicant/domain/ApplicantRepository.java
@@ -1,7 +1,6 @@
 package com.ryc.api.v2.applicant.domain;
 
 import java.util.List;
-import java.util.Optional;
 
 import com.ryc.api.v2.applicant.domain.enums.ApplicantStatus;
 

--- a/server/src/main/java/com/ryc/api/v2/applicant/domain/ApplicantRepository.java
+++ b/server/src/main/java/com/ryc/api/v2/applicant/domain/ApplicantRepository.java
@@ -12,4 +12,6 @@ public interface ApplicantRepository {
   List<Applicant> findAllByAnnouncementId(String announcementId);
 
   List<Applicant> findAllByAnnouncementIdAndStatus(String announcementId, ApplicantStatus status);
+
+  Boolean existsByAnnouncementIdAndEmail(String announcementId, String email);
 }

--- a/server/src/main/java/com/ryc/api/v2/applicant/domain/enums/ApplicantStatus.java
+++ b/server/src/main/java/com/ryc/api/v2/applicant/domain/enums/ApplicantStatus.java
@@ -1,11 +1,23 @@
 package com.ryc.api.v2.applicant.domain.enums;
 
+import java.util.stream.Stream;
+
 public enum ApplicantStatus {
-    PENDING,
-    DOCUMENT_PASS,
-    DOCUMENT_FAIL,
-    INTERVIEW_PASS,
-    INTERVIEW_FAIL,
-    FINAL_PASS,
-    FINAL_FAIL
+  PENDING,
+  DOCUMENT_PASS,
+  DOCUMENT_FAIL,
+  INTERVIEW_PASS,
+  INTERVIEW_FAIL,
+  FINAL_PASS,
+  FINAL_FAIL;
+
+  public static ApplicantStatus from(String value) {
+    if (value == null) {
+      return null;
+    }
+    return Stream.of(ApplicantStatus.values())
+        .filter(applicantStatus -> applicantStatus.name().equalsIgnoreCase(value))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 status 값입니다: " + value));
+  }
 }

--- a/server/src/main/java/com/ryc/api/v2/applicant/infra/ApplicantRepositoryImpl.java
+++ b/server/src/main/java/com/ryc/api/v2/applicant/infra/ApplicantRepositoryImpl.java
@@ -49,4 +49,9 @@ public class ApplicantRepositoryImpl implements ApplicantRepository {
         .map(ApplicantMapper::toDomain)
         .collect(Collectors.toList());
   }
+
+  @Override
+  public Boolean existsByAnnouncementIdAndEmail(String announcementId, String email) {
+    return applicantJpaRepository.existsByAnnouncementIdAndEmail(announcementId, email);
+  }
 }

--- a/server/src/main/java/com/ryc/api/v2/applicant/infra/ApplicantRepositoryImpl.java
+++ b/server/src/main/java/com/ryc/api/v2/applicant/infra/ApplicantRepositoryImpl.java
@@ -1,36 +1,49 @@
 package com.ryc.api.v2.applicant.infra;
 
-import com.ryc.api.v2.applicant.domain.Applicant;
-import com.ryc.api.v2.applicant.domain.ApplicantRepository;
-import com.ryc.api.v2.applicant.infra.jpa.ApplicantJpaRepository;
-import com.ryc.api.v2.applicant.infra.mapper.ApplicantMapper;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.stereotype.Repository;
+
+import com.ryc.api.v2.applicant.domain.Applicant;
+import com.ryc.api.v2.applicant.domain.ApplicantRepository;
+import com.ryc.api.v2.applicant.domain.enums.ApplicantStatus;
+import com.ryc.api.v2.applicant.infra.jpa.ApplicantJpaRepository;
+import com.ryc.api.v2.applicant.infra.mapper.ApplicantMapper;
+
+import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
 public class ApplicantRepositoryImpl implements ApplicantRepository {
 
-    private final ApplicantJpaRepository applicantJpaRepository;
+  private final ApplicantJpaRepository applicantJpaRepository;
 
-    @Override
-    public Applicant save(Applicant applicant) {
-        return ApplicantMapper.toDomain(applicantJpaRepository.save(ApplicantMapper.toEntity(applicant)));
-    }
+  @Override
+  public Applicant save(Applicant applicant) {
+    return ApplicantMapper.toDomain(
+        applicantJpaRepository.save(ApplicantMapper.toEntity(applicant)));
+  }
 
-    @Override
-    public Optional<Applicant> findById(String id) {
-        return applicantJpaRepository.findById(id).map(ApplicantMapper::toDomain);
-    }
+  @Override
+  public Applicant findById(String id) {
+    return applicantJpaRepository.findById(id).map(ApplicantMapper::toDomain).orElseThrow(() -> new EntityNotFoundException("Applicant not found"));
+  }
 
-    @Override
-    public List<Applicant> findAllByAnnouncementId(String announcementId) {
-        return applicantJpaRepository.findAllByAnnouncementId(announcementId).stream()
-                .map(ApplicantMapper::toDomain)
-                .collect(Collectors.toList());
-    }
+  @Override
+  public List<Applicant> findAllByAnnouncementId(String announcementId) {
+    return applicantJpaRepository.findAllByAnnouncementId(announcementId).stream()
+        .map(ApplicantMapper::toDomain)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<Applicant> findAllByAnnouncementIdAndStatus(
+      String announcementId, ApplicantStatus status) {
+    return applicantJpaRepository.findAllByAnnouncementIdAndStatus(announcementId, status).stream()
+        .map(ApplicantMapper::toDomain)
+        .collect(Collectors.toList());
+  }
 }

--- a/server/src/main/java/com/ryc/api/v2/applicant/infra/ApplicantRepositoryImpl.java
+++ b/server/src/main/java/com/ryc/api/v2/applicant/infra/ApplicantRepositoryImpl.java
@@ -1,10 +1,10 @@
 package com.ryc.api.v2.applicant.infra;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import jakarta.persistence.EntityNotFoundException;
+
 import org.springframework.stereotype.Repository;
 
 import com.ryc.api.v2.applicant.domain.Applicant;
@@ -29,7 +29,10 @@ public class ApplicantRepositoryImpl implements ApplicantRepository {
 
   @Override
   public Applicant findById(String id) {
-    return applicantJpaRepository.findById(id).map(ApplicantMapper::toDomain).orElseThrow(() -> new EntityNotFoundException("Applicant not found"));
+    return applicantJpaRepository
+        .findById(id)
+        .map(ApplicantMapper::toDomain)
+        .orElseThrow(() -> new EntityNotFoundException("Applicant not found"));
   }
 
   @Override

--- a/server/src/main/java/com/ryc/api/v2/applicant/infra/entity/ApplicantEntity.java
+++ b/server/src/main/java/com/ryc/api/v2/applicant/infra/entity/ApplicantEntity.java
@@ -1,8 +1,12 @@
 package com.ryc.api.v2.applicant.infra.entity;
 
+import java.util.List;
+
+import jakarta.persistence.*;
+
 import com.ryc.api.v2.applicant.domain.enums.ApplicantStatus;
 import com.ryc.api.v2.common.entity.BaseEntity;
-import jakarta.persistence.*;
+
 import lombok.*;
 
 @Entity
@@ -12,18 +16,21 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ApplicantEntity extends BaseEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private String id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private String id;
 
-    @Column(nullable = false, name = "announcement_id")
-    private String announcementId;
+  @Column(nullable = false, name = "announcement_id")
+  private String announcementId;
 
-    private String email;
-    private String name;
+  private String email;
+  private String name;
 
-    @Enumerated(EnumType.STRING)
-    private ApplicantStatus status;
+  @Enumerated(EnumType.STRING)
+  private ApplicantStatus status;
 
-    private Boolean isDeleted;
+  @OneToMany(mappedBy = "applicant", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<ApplicantPersonalInfoEntity> personalInfos;
+
+  private Boolean isDeleted;
 }

--- a/server/src/main/java/com/ryc/api/v2/applicant/infra/entity/ApplicantPersonalInfoEntity.java
+++ b/server/src/main/java/com/ryc/api/v2/applicant/infra/entity/ApplicantPersonalInfoEntity.java
@@ -1,0 +1,28 @@
+package com.ryc.api.v2.applicant.infra.entity;
+
+import jakarta.persistence.*;
+
+import com.ryc.api.v2.applicationForm.domain.enums.PersonalInfoQuestionType;
+
+import lombok.*;
+
+@Entity
+@Table(name = "applicant_personal_infos")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ApplicantPersonalInfoEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private String id;
+
+  @Enumerated(EnumType.STRING)
+  private PersonalInfoQuestionType questionType;
+
+  private String value;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "applicant_id")
+  private ApplicantEntity applicant;
+}

--- a/server/src/main/java/com/ryc/api/v2/applicant/infra/jpa/ApplicantJpaRepository.java
+++ b/server/src/main/java/com/ryc/api/v2/applicant/infra/jpa/ApplicantJpaRepository.java
@@ -1,12 +1,17 @@
 package com.ryc.api.v2.applicant.infra.jpa;
 
-import com.ryc.api.v2.applicant.infra.entity.ApplicantEntity;
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
+import com.ryc.api.v2.applicant.domain.enums.ApplicantStatus;
+import com.ryc.api.v2.applicant.infra.entity.ApplicantEntity;
 
 @Repository
 public interface ApplicantJpaRepository extends JpaRepository<ApplicantEntity, String> {
-    List<ApplicantEntity> findAllByAnnouncementId(String announcementId);
+  List<ApplicantEntity> findAllByAnnouncementId(String announcementId);
+
+  List<ApplicantEntity> findAllByAnnouncementIdAndStatus(
+      String announcementId, ApplicantStatus status);
 }

--- a/server/src/main/java/com/ryc/api/v2/applicant/infra/jpa/ApplicantJpaRepository.java
+++ b/server/src/main/java/com/ryc/api/v2/applicant/infra/jpa/ApplicantJpaRepository.java
@@ -14,4 +14,6 @@ public interface ApplicantJpaRepository extends JpaRepository<ApplicantEntity, S
 
   List<ApplicantEntity> findAllByAnnouncementIdAndStatus(
       String announcementId, ApplicantStatus status);
+
+  Boolean existsByAnnouncementIdAndEmail(String announcementId, String email);
 }

--- a/server/src/main/java/com/ryc/api/v2/applicant/infra/mapper/ApplicantMapper.java
+++ b/server/src/main/java/com/ryc/api/v2/applicant/infra/mapper/ApplicantMapper.java
@@ -1,30 +1,48 @@
 package com.ryc.api.v2.applicant.infra.mapper;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import com.ryc.api.v2.applicant.domain.Applicant;
+import com.ryc.api.v2.applicant.domain.ApplicantPersonalInfo;
 import com.ryc.api.v2.applicant.infra.entity.ApplicantEntity;
+import com.ryc.api.v2.applicant.infra.entity.ApplicantPersonalInfoEntity;
 
 public class ApplicantMapper {
-    public static Applicant toDomain(ApplicantEntity entity) {
-        if (entity == null) return null;
-        return Applicant.builder()
-                .id(entity.getId())
-                .userId(entity.getId())
-                .announcementId(entity.getAnnouncementId())
-                .status(entity.getStatus())
-                .isDeleted(entity.getIsDeleted())
-                .email(entity.getEmail())
-                .build();
-    }
+  public static Applicant toDomain(ApplicantEntity entity) {
+    if (entity == null) return null;
 
-    public static ApplicantEntity toEntity(Applicant domain) {
-        if (domain == null) return null;
-        return ApplicantEntity.builder()
-                .id(domain.getId())
-                .announcementId(domain.getAnnouncementId())
-                .status(domain.getStatus())
-                .isDeleted(domain.getIsDeleted())
-                .email(domain.getEmail())
-                .name(domain.getName())
-                .build();
-    }
+    List<ApplicantPersonalInfo> personalInfos =
+        entity.getPersonalInfos().stream().map(ApplicantPersonalInfoMapper::toDomain).toList();
+
+    return Applicant.builder()
+        .id(entity.getId())
+        .name(entity.getName())
+        .announcementId(entity.getAnnouncementId())
+        .status(entity.getStatus())
+        .isDeleted(entity.getIsDeleted())
+        .email(entity.getEmail())
+        .personalInfos(personalInfos)
+        .build();
+  }
+
+  public static ApplicantEntity toEntity(Applicant domain) {
+    if (domain == null) return null;
+
+    List<ApplicantPersonalInfoEntity> personalInfos =
+        domain.getPersonalInfos().stream()
+            .map(ApplicantPersonalInfoMapper::toEntity)
+            .collect(Collectors.toCollection(ArrayList::new));
+
+    return ApplicantEntity.builder()
+        .id(domain.getId())
+        .announcementId(domain.getAnnouncementId())
+        .status(domain.getStatus())
+        .isDeleted(domain.getIsDeleted())
+        .email(domain.getEmail())
+        .name(domain.getName())
+        .personalInfos(personalInfos)
+        .build();
+  }
 }

--- a/server/src/main/java/com/ryc/api/v2/applicant/infra/mapper/ApplicantPersonalInfoMapper.java
+++ b/server/src/main/java/com/ryc/api/v2/applicant/infra/mapper/ApplicantPersonalInfoMapper.java
@@ -1,0 +1,27 @@
+package com.ryc.api.v2.applicant.infra.mapper;
+
+import com.ryc.api.v2.applicant.domain.ApplicantPersonalInfo;
+import com.ryc.api.v2.applicant.infra.entity.ApplicantPersonalInfoEntity;
+
+public class ApplicantPersonalInfoMapper {
+
+  public static ApplicantPersonalInfo toDomain(ApplicantPersonalInfoEntity entity) {
+    if (entity == null) return null;
+
+    return ApplicantPersonalInfo.builder()
+        .id(entity.getId())
+        .questionType(entity.getQuestionType())
+        .value(entity.getValue())
+        .build();
+  }
+
+  public static ApplicantPersonalInfoEntity toEntity(ApplicantPersonalInfo domain) {
+    if (domain == null) return null;
+
+    return ApplicantPersonalInfoEntity.builder()
+        .id(domain.getId())
+        .questionType(domain.getQuestionType())
+        .value(domain.getValue())
+        .build();
+  }
+}

--- a/server/src/main/java/com/ryc/api/v2/applicant/presentation/dto/request/ApplicantCreateRequest.java
+++ b/server/src/main/java/com/ryc/api/v2/applicant/presentation/dto/request/ApplicantCreateRequest.java
@@ -1,0 +1,22 @@
+package com.ryc.api.v2.applicant.presentation.dto.request;
+
+import java.util.List;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import lombok.Builder;
+
+@Builder
+public record ApplicantCreateRequest(
+    @NotBlank(message = "email shouldn't be blank") String email,
+    @NotBlank(message = "name shouldn't be blank") String name,
+    List<
+            @NotNull(message = "personalInfo shouldn't be null") @Valid
+            ApplicantPersonalInfoCreateRequest>
+        personalInfos) {
+  public ApplicantCreateRequest {
+    personalInfos = personalInfos == null ? List.of() : personalInfos;
+  }
+}

--- a/server/src/main/java/com/ryc/api/v2/applicant/presentation/dto/request/ApplicantPersonalInfoCreateRequest.java
+++ b/server/src/main/java/com/ryc/api/v2/applicant/presentation/dto/request/ApplicantPersonalInfoCreateRequest.java
@@ -1,0 +1,14 @@
+package com.ryc.api.v2.applicant.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import com.ryc.api.v2.applicationForm.domain.enums.PersonalInfoQuestionType;
+
+import lombok.Builder;
+
+@Builder
+public record ApplicantPersonalInfoCreateRequest(
+    @NotNull(message = "questionId shouldn't be null")
+        PersonalInfoQuestionType personalInfoQuestionType,
+    @NotBlank(message = "value shouldn't be blank") String value) {}

--- a/server/src/main/java/com/ryc/api/v2/applicant/presentation/dto/response/ApplicantPersonalInfoResponse.java
+++ b/server/src/main/java/com/ryc/api/v2/applicant/presentation/dto/response/ApplicantPersonalInfoResponse.java
@@ -1,0 +1,19 @@
+package com.ryc.api.v2.applicant.presentation.dto.response;
+
+import com.ryc.api.v2.applicant.domain.ApplicantPersonalInfo;
+
+import lombok.Builder;
+
+@Builder
+public record ApplicantPersonalInfoResponse(
+    String id, String PersonalInfoQuestionType, String value) {
+
+  public static ApplicantPersonalInfoResponse from(ApplicantPersonalInfo personalInfo) {
+
+    return ApplicantPersonalInfoResponse.builder()
+        .id(personalInfo.getId())
+        .PersonalInfoQuestionType(personalInfo.getQuestionType().name())
+        .value(personalInfo.getValue())
+        .build();
+  }
+}

--- a/server/src/main/java/com/ryc/api/v2/applicant/presentation/dto/response/ApplicantResponse.java
+++ b/server/src/main/java/com/ryc/api/v2/applicant/presentation/dto/response/ApplicantResponse.java
@@ -1,0 +1,30 @@
+package com.ryc.api.v2.applicant.presentation.dto.response;
+
+import java.util.List;
+
+import com.ryc.api.v2.applicant.domain.Applicant;
+import com.ryc.api.v2.applicant.domain.enums.ApplicantStatus;
+
+import lombok.Builder;
+
+@Builder
+public record ApplicantResponse(
+    String id,
+    String email,
+    String name,
+    ApplicantStatus status,
+    List<ApplicantPersonalInfoResponse> personalInfos) {
+
+  public static ApplicantResponse from(Applicant applicant) {
+    List<ApplicantPersonalInfoResponse> personalInfos =
+        applicant.getPersonalInfos().stream().map(ApplicantPersonalInfoResponse::from).toList();
+
+    return ApplicantResponse.builder()
+        .id(applicant.getId())
+        .email(applicant.getEmail())
+        .name(applicant.getName())
+        .status(applicant.getStatus())
+        .personalInfos(personalInfos)
+        .build();
+  }
+}

--- a/server/src/main/java/com/ryc/api/v2/application/common/exception/code/ApplicationCreateErrorCode.java
+++ b/server/src/main/java/com/ryc/api/v2/application/common/exception/code/ApplicationCreateErrorCode.java
@@ -15,6 +15,7 @@ public enum ApplicationCreateErrorCode implements ErrorCode {
   INVALID_QUESTION_ID(HttpStatus.CONFLICT, "제출된 변의 질문 ID 유효하지 않거나 해당 공고에 속하지 않습니다."),
   INVALID_ANSWER_FORMAT(HttpStatus.CONFLICT, "답변의 형식이 올바르지 않습니다."),
   ANNOUNCEMENT_NOT_RECRUITING(HttpStatus.CONFLICT, "공고 지원은 모집중 일때만 가능 합니다."),
+  DUPLICATE_APPLICATION(HttpStatus.CONFLICT, "이미 해당 공고에 지원한 이메일 입니다."),
   ;
 
   private final HttpStatus httpStatus;

--- a/server/src/main/java/com/ryc/api/v2/application/common/exception/code/ApplicationCreateErrorCode.java
+++ b/server/src/main/java/com/ryc/api/v2/application/common/exception/code/ApplicationCreateErrorCode.java
@@ -1,0 +1,22 @@
+package com.ryc.api.v2.application.common.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+import com.ryc.api.v2.common.exception.code.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ApplicationCreateErrorCode implements ErrorCode {
+  MISSING_REQUIRED_PERSONAL_INFO_ANSWER(HttpStatus.CONFLICT, "필수 개인정보 질문에 대한 답변이 누락되었습니다."),
+  DUPLICATE_PERSONAL_INFO_ANSWER(HttpStatus.CONFLICT, "이름과 이메일은 개인정보 질문으로 중복 제출할 수 없습니다."),
+  INVALID_QUESTION_ID(HttpStatus.CONFLICT, "제출된 변의 질문 ID 유효하지 않거나 해당 공고에 속하지 않습니다."),
+  INVALID_ANSWER_FORMAT(HttpStatus.CONFLICT, "답변의 형식이 올바르지 않습니다."),
+  ANNOUNCEMENT_NOT_RECRUITING(HttpStatus.CONFLICT, "공고 지원은 모집중 일때만 가능 합니다."),
+  ;
+
+  private final HttpStatus httpStatus;
+  private final String message;
+}

--- a/server/src/main/java/com/ryc/api/v2/application/domain/Answer.java
+++ b/server/src/main/java/com/ryc/api/v2/application/domain/Answer.java
@@ -1,16 +1,78 @@
 package com.ryc.api.v2.application.domain;
 
+import java.util.List;
+
+import com.ryc.api.v2.application.common.exception.code.ApplicationCreateErrorCode;
+import com.ryc.api.v2.application.presentation.dto.request.AnswerCreateRequest;
+import com.ryc.api.v2.applicationForm.domain.Question;
+import com.ryc.api.v2.common.constant.DomainDefaultValues;
+import com.ryc.api.v2.common.exception.custom.BusinessRuleException;
+
 import lombok.Builder;
 import lombok.Getter;
-
-import java.util.List;
 
 @Getter
 @Builder
 public class Answer {
-    private final String id;
-    private final String questionId;
-    private final String answerText;
-    private final List<AnswerChoice> choices;
-    private final String fileMetadataId;
+  private final String id;
+  private final String questionId;
+  private final String textAnswer;
+  private final List<AnswerChoice> choices;
+  private final String fileMetadataId;
+
+  public static Answer initialize(AnswerCreateRequest request) {
+    List<AnswerChoice> choices =
+        request.answerChoices().stream().map(AnswerChoice::initialize).toList();
+
+    return Answer.builder()
+        .id(DomainDefaultValues.DEFAULT_INITIAL_ID)
+        .questionId(request.questionId())
+        .textAnswer(request.textAnswer())
+        .choices(choices)
+        .fileMetadataId(request.fileMetadataId())
+        .build();
+  }
+
+  public void checkBusinessRules(Question question) {
+    switch (question.getQuestionType()) {
+      case LONG_ANSWER, SHORT_ANSWER -> validateTextAnswer();
+      case SINGLE_CHOICE -> validateSingleChoiceAnswer();
+      case MULTIPLE_CHOICE -> validateMultipleChoiceAnswer();
+      case FILE -> validateFileAnswer();
+    }
+  }
+
+  /** 주관식 질문 응답객체 validation */
+  private void validateTextAnswer() {
+    if (textAnswer == null
+        || textAnswer.isBlank()
+        || !choices.isEmpty()
+        || fileMetadataId != null) {
+      throw new BusinessRuleException(ApplicationCreateErrorCode.INVALID_ANSWER_FORMAT);
+    }
+  }
+
+  /** 단일 선택 질문 응답객체 validation */
+  private void validateSingleChoiceAnswer() {
+    if (choices.size() != 1 || textAnswer != null || fileMetadataId != null) {
+      throw new BusinessRuleException(ApplicationCreateErrorCode.INVALID_ANSWER_FORMAT);
+    }
+  }
+
+  /** 다중 선택 질문 응답객체 validation */
+  private void validateMultipleChoiceAnswer() {
+    if (choices.isEmpty() || textAnswer != null || fileMetadataId != null) {
+      throw new BusinessRuleException(ApplicationCreateErrorCode.INVALID_ANSWER_FORMAT);
+    }
+  }
+
+  /** 파일 질문 응답객체 validation */
+  private void validateFileAnswer() {
+    if (fileMetadataId == null
+        || fileMetadataId.isBlank()
+        || textAnswer != null
+        || !choices.isEmpty()) {
+      throw new BusinessRuleException(ApplicationCreateErrorCode.INVALID_ANSWER_FORMAT);
+    }
+  }
 }

--- a/server/src/main/java/com/ryc/api/v2/application/domain/Answer.java
+++ b/server/src/main/java/com/ryc/api/v2/application/domain/Answer.java
@@ -35,43 +35,61 @@ public class Answer {
 
   public void checkBusinessRules(Question question) {
     switch (question.getQuestionType()) {
-      case LONG_ANSWER, SHORT_ANSWER -> validateTextAnswer();
-      case SINGLE_CHOICE -> validateSingleChoiceAnswer();
-      case MULTIPLE_CHOICE -> validateMultipleChoiceAnswer();
-      case FILE -> validateFileAnswer();
+      case LONG_ANSWER, SHORT_ANSWER -> validateTextAnswer(question.isRequired());
+      case SINGLE_CHOICE -> validateSingleChoiceAnswer(question.isRequired());
+      case MULTIPLE_CHOICE -> validateMultipleChoiceAnswer(question.isRequired());
+      case FILE -> validateFileAnswer(question.isRequired());
     }
   }
 
   /** 주관식 질문 응답객체 validation */
-  private void validateTextAnswer() {
-    if (textAnswer == null
-        || textAnswer.isBlank()
-        || !choices.isEmpty()
+  private void validateTextAnswer(Boolean isRequired) {
+    // textAnswer외에 다른 입력값이 들어간 경우
+    if (!choices.isEmpty()
         || fileMetadataId != null) {
+      throw new BusinessRuleException(ApplicationCreateErrorCode.INVALID_ANSWER_FORMAT);
+    }
+
+    // 필수 입력값인데 비어있는 경우
+    if(isRequired && textAnswer == null) {
       throw new BusinessRuleException(ApplicationCreateErrorCode.INVALID_ANSWER_FORMAT);
     }
   }
 
   /** 단일 선택 질문 응답객체 validation */
-  private void validateSingleChoiceAnswer() {
-    if (choices.size() != 1 || textAnswer != null || fileMetadataId != null) {
+  private void validateSingleChoiceAnswer(Boolean isRequired) {
+    // choices외에 다른 입력값이 들어온 경우
+    if (textAnswer != null || fileMetadataId != null) {
+      throw new BusinessRuleException(ApplicationCreateErrorCode.INVALID_ANSWER_FORMAT);
+    }
+
+    // 필수 입력값인데 올바른 입력값이 아닌경우 (단일 선택)
+    if (isRequired&&choices.size()!=1) {
       throw new BusinessRuleException(ApplicationCreateErrorCode.INVALID_ANSWER_FORMAT);
     }
   }
 
   /** 다중 선택 질문 응답객체 validation */
-  private void validateMultipleChoiceAnswer() {
-    if (choices.isEmpty() || textAnswer != null || fileMetadataId != null) {
+  private void validateMultipleChoiceAnswer(Boolean isRequired) {
+    if (textAnswer != null || fileMetadataId != null) {
+      throw new BusinessRuleException(ApplicationCreateErrorCode.INVALID_ANSWER_FORMAT);
+    }
+
+    // 필수 입력값인데 올바른 입력값이 아닌경우 (다중 선택)
+    if (isRequired && choices.isEmpty()) {
       throw new BusinessRuleException(ApplicationCreateErrorCode.INVALID_ANSWER_FORMAT);
     }
   }
 
   /** 파일 질문 응답객체 validation */
-  private void validateFileAnswer() {
-    if (fileMetadataId == null
-        || fileMetadataId.isBlank()
-        || textAnswer != null
+  private void validateFileAnswer(Boolean isRequired) {
+    if (textAnswer != null
         || !choices.isEmpty()) {
+      throw new BusinessRuleException(ApplicationCreateErrorCode.INVALID_ANSWER_FORMAT);
+    }
+
+    // 필수 입력값인데 비어있는 경우
+    if (isRequired && fileMetadataId == null) {
       throw new BusinessRuleException(ApplicationCreateErrorCode.INVALID_ANSWER_FORMAT);
     }
   }

--- a/server/src/main/java/com/ryc/api/v2/application/domain/AnswerChoice.java
+++ b/server/src/main/java/com/ryc/api/v2/application/domain/AnswerChoice.java
@@ -1,11 +1,21 @@
 package com.ryc.api.v2.application.domain;
 
+import com.ryc.api.v2.application.presentation.dto.request.AnswerChoiceCreateRequest;
+import com.ryc.api.v2.common.constant.DomainDefaultValues;
+
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
 public class AnswerChoice {
-    private final String id;
-    private final String optionId;
+  private final String id;
+  private final String optionId;
+
+  public static AnswerChoice initialize(AnswerChoiceCreateRequest request) {
+    return AnswerChoice.builder()
+        .id(DomainDefaultValues.DEFAULT_INITIAL_ID)
+        .optionId(request.optionId())
+        .build();
+  }
 }

--- a/server/src/main/java/com/ryc/api/v2/application/domain/Application.java
+++ b/server/src/main/java/com/ryc/api/v2/application/domain/Application.java
@@ -1,21 +1,57 @@
 package com.ryc.api.v2.application.domain;
 
-import lombok.Builder;
-import lombok.Getter;
-
-import lombok.Builder;
-import lombok.Getter;
-
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.ryc.api.v2.application.common.exception.code.ApplicationCreateErrorCode;
+import com.ryc.api.v2.application.presentation.dto.request.ApplicationCreateRequest;
+import com.ryc.api.v2.applicationForm.domain.ApplicationForm;
+import com.ryc.api.v2.applicationForm.domain.Question;
+import com.ryc.api.v2.common.constant.DomainDefaultValues;
+import com.ryc.api.v2.common.exception.custom.BusinessRuleException;
+
+import lombok.Builder;
+import lombok.Getter;
 
 @Getter
 @Builder
 public class Application {
+  private final String id;
+  private String applicantId;
+  private final List<Answer> answers;
+  private final LocalDateTime createdAt;
 
-    private final String id;
-    private final String applicantId;
-    private final List<Answer> answers;
-    private final LocalDateTime createdAt;
-    private final LocalDateTime updatedAt;
+  public static Application initialize(ApplicationCreateRequest request) {
+    List<Answer> answers = request.answers().stream().map(Answer::initialize).toList();
+
+    return Application.builder()
+        .id(DomainDefaultValues.DEFAULT_INITIAL_ID)
+        .applicantId(DomainDefaultValues.DEFAULT_INITIAL_ID)
+        .answers(answers)
+        .build();
+  }
+
+  public void validate(ApplicationForm applicationForm) {
+    Map<String, Question> questionMap =
+        Stream.concat(
+                applicationForm.getApplicationQuestions().stream(),
+                applicationForm.getPreQuestions().stream())
+            .collect(Collectors.toMap(Question::getId, Function.identity()));
+
+    for (Answer answer : answers) {
+      Question question = questionMap.get(answer.getQuestionId());
+      if (question == null) {
+        throw new BusinessRuleException(ApplicationCreateErrorCode.INVALID_QUESTION_ID);
+      }
+      answer.checkBusinessRules(question);
+    }
+  }
+
+  public void assignApplicantId(String applicantId) {
+    this.applicantId = applicantId;
+  }
 }

--- a/server/src/main/java/com/ryc/api/v2/application/domain/Application.java
+++ b/server/src/main/java/com/ryc/api/v2/application/domain/Application.java
@@ -21,21 +21,21 @@ import lombok.Getter;
 @Builder
 public class Application {
   private final String id;
-  private String applicantId;
+  private final String applicantId;
   private final List<Answer> answers;
   private final LocalDateTime createdAt;
 
-  public static Application initialize(ApplicationCreateRequest request) {
+  public static Application initialize(ApplicationCreateRequest request, String applicantId) {
     List<Answer> answers = request.answers().stream().map(Answer::initialize).toList();
 
     return Application.builder()
         .id(DomainDefaultValues.DEFAULT_INITIAL_ID)
-        .applicantId(DomainDefaultValues.DEFAULT_INITIAL_ID)
+        .applicantId(applicantId)
         .answers(answers)
         .build();
   }
 
-  public void validate(ApplicationForm applicationForm) {
+  public void checkBusinessRules(ApplicationForm applicationForm) {
     Map<String, Question> questionMap =
         Stream.concat(
                 applicationForm.getApplicationQuestions().stream(),
@@ -49,9 +49,5 @@ public class Application {
       }
       answer.checkBusinessRules(question);
     }
-  }
-
-  public void assignApplicantId(String applicantId) {
-    this.applicantId = applicantId;
   }
 }

--- a/server/src/main/java/com/ryc/api/v2/application/domain/ApplicationRepository.java
+++ b/server/src/main/java/com/ryc/api/v2/application/domain/ApplicationRepository.java
@@ -3,6 +3,8 @@ package com.ryc.api.v2.application.domain;
 import java.util.List;
 
 public interface ApplicationRepository {
+  Application save(Application application, String applicantId);
+
   Application findByApplicantId(String applicantId);
 
   List<Application> findAllByApplicantIdIn(List<String> applicantIds);

--- a/server/src/main/java/com/ryc/api/v2/application/domain/ApplicationRepository.java
+++ b/server/src/main/java/com/ryc/api/v2/application/domain/ApplicationRepository.java
@@ -3,6 +3,7 @@ package com.ryc.api.v2.application.domain;
 import java.util.List;
 
 public interface ApplicationRepository {
-    Application save(Application application);
-    Application findByApplicantId(String applicantId);
+  Application findByApplicantId(String applicantId);
+
+  List<Application> findAllByApplicantIdIn(List<String> applicantIds);
 }

--- a/server/src/main/java/com/ryc/api/v2/application/infra/ApplicationRepositoryImpl.java
+++ b/server/src/main/java/com/ryc/api/v2/application/infra/ApplicationRepositoryImpl.java
@@ -1,27 +1,42 @@
 package com.ryc.api.v2.application.infra;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import jakarta.persistence.EntityNotFoundException;
+
+import org.springframework.stereotype.Repository;
+
+import com.ryc.api.v2.application.domain.Answer;
 import com.ryc.api.v2.application.domain.Application;
 import com.ryc.api.v2.application.domain.ApplicationRepository;
 import com.ryc.api.v2.application.infra.jpa.ApplicationJpaRepository;
 import com.ryc.api.v2.application.infra.mapper.ApplicationMapper;
+import com.ryc.api.v2.s3.infra.entity.FileMetadataEntity;
+import com.ryc.api.v2.s3.infra.jpa.FileMetadataJpaRepository;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
 public class ApplicationRepositoryImpl implements ApplicationRepository {
 
-    private final ApplicationJpaRepository applicationJpaRepository;
+  private final ApplicationJpaRepository applicationJpaRepository;
+  private final FileMetadataJpaRepository fileMetadataJpaRepository;
 
-    @Override
-    public Application save(Application application) {
-        return ApplicationMapper.toDomain(applicationJpaRepository.save(ApplicationMapper.toEntity(application)));
-    }
+  @Override
+  public Application findByApplicantId(String applicantId) {
+    return applicationJpaRepository
+        .findByApplicantId(applicantId)
+        .map(ApplicationMapper::toDomain)
+        .orElseThrow(() -> new EntityNotFoundException("Application not found"));
+  }
 
-    @Override
-    public Application findByApplicantId(String applicantId) {
-        return applicationJpaRepository.findByApplicantId(applicantId)
-                .map(ApplicationMapper::toDomain)
-                .orElse(null);
-    }
+  @Override
+  public List<Application> findAllByApplicantIdIn(List<String> applicantIds) {
+    return applicationJpaRepository.findAllByApplicantIdIn(applicantIds).stream()
+        .map(ApplicationMapper::toDomain)
+        .collect(Collectors.toList());
+  }
 }

--- a/server/src/main/java/com/ryc/api/v2/application/infra/ApplicationRepositoryImpl.java
+++ b/server/src/main/java/com/ryc/api/v2/application/infra/ApplicationRepositoryImpl.java
@@ -26,6 +26,20 @@ public class ApplicationRepositoryImpl implements ApplicationRepository {
   private final FileMetadataJpaRepository fileMetadataJpaRepository;
 
   @Override
+  public Application save(Application application, String applicantId) {
+    List<String> fileMetadataIds =
+        application.getAnswers().stream().map(Answer::getFileMetadataId).toList();
+
+    Map<String, FileMetadataEntity> fileMetadataMap =
+        fileMetadataJpaRepository.findAllById(fileMetadataIds).stream()
+            .collect(Collectors.toMap(FileMetadataEntity::getId, entity -> entity));
+
+    return ApplicationMapper.toDomain(
+        applicationJpaRepository.save(
+            ApplicationMapper.toEntity(application, fileMetadataMap, applicantId)));
+  }
+
+  @Override
   public Application findByApplicantId(String applicantId) {
     return applicationJpaRepository
         .findByApplicantId(applicantId)

--- a/server/src/main/java/com/ryc/api/v2/application/infra/entity/AnswerChoiceEntity.java
+++ b/server/src/main/java/com/ryc/api/v2/application/infra/entity/AnswerChoiceEntity.java
@@ -1,7 +1,9 @@
 package com.ryc.api.v2.application.infra.entity;
 
-import com.ryc.api.v2.common.entity.BaseEntity;
 import jakarta.persistence.*;
+
+import com.ryc.api.v2.common.entity.BaseEntity;
+
 import lombok.*;
 
 @Entity
@@ -11,14 +13,14 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class AnswerChoiceEntity extends BaseEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private String id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private String id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "answer_id")
-    private AnswerEntity answer;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "answer_id")
+  private AnswerEntity answer;
 
-    @Column(nullable = false, name = "option_id")
-    private String optionId;
+  @Column(nullable = false, name = "option_id")
+  private String optionId;
 }

--- a/server/src/main/java/com/ryc/api/v2/application/infra/entity/AnswerEntity.java
+++ b/server/src/main/java/com/ryc/api/v2/application/infra/entity/AnswerEntity.java
@@ -1,37 +1,40 @@
 package com.ryc.api.v2.application.infra.entity;
 
+import java.util.List;
+
+import jakarta.persistence.*;
+
 import com.ryc.api.v2.common.entity.BaseEntity;
 import com.ryc.api.v2.s3.infra.entity.FileMetadataEntity;
-import jakarta.persistence.*;
-import lombok.*;
 
-import java.util.List;
+import lombok.*;
 
 @Entity
 @Table(name = "answers")
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class AnswerEntity extends BaseEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private String id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private String id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "application_id")
-    private ApplicationEntity application;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "application_id")
+  private ApplicationEntity application;
 
-    @Column(nullable = false, name = "question_id")
-    private String questionId;
+  @Column(nullable = false, name = "question_id")
+  private String questionId;
 
-    @Column(columnDefinition = "TEXT")
-    private String answerText;
+  @Column(columnDefinition = "TEXT")
+  private String textAnswer;
 
-    @OneToMany(mappedBy = "answer", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<AnswerChoiceEntity> choices;
+  @OneToMany(mappedBy = "answer", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<AnswerChoiceEntity> choices;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "file_metadata_id")
-    private FileMetadataEntity fileMetadata;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "file_metadata_id")
+  private FileMetadataEntity fileMetadata;
 }

--- a/server/src/main/java/com/ryc/api/v2/application/infra/entity/ApplicationEntity.java
+++ b/server/src/main/java/com/ryc/api/v2/application/infra/entity/ApplicationEntity.java
@@ -1,25 +1,28 @@
 package com.ryc.api.v2.application.infra.entity;
 
-import com.ryc.api.v2.common.entity.BaseEntity;
-import jakarta.persistence.*;
-import lombok.*;
-
 import java.util.List;
+
+import jakarta.persistence.*;
+
+import com.ryc.api.v2.common.entity.BaseEntity;
+
+import lombok.*;
 
 @Entity
 @Table(name = "applications")
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ApplicationEntity extends BaseEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private String id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private String id;
 
-    @Column(nullable = false, name = "applicant_id")
-    private String applicantId;
+  @Column(nullable = false, name = "applicant_id")
+  private String applicantId;
 
-    @OneToMany(mappedBy = "application", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<AnswerEntity> answers;
+  @OneToMany(mappedBy = "application", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<AnswerEntity> answers;
 }

--- a/server/src/main/java/com/ryc/api/v2/application/infra/jpa/AnswerChoiceJpaRepository.java
+++ b/server/src/main/java/com/ryc/api/v2/application/infra/jpa/AnswerChoiceJpaRepository.java
@@ -1,9 +1,9 @@
 package com.ryc.api.v2.application.infra.jpa;
 
-import com.ryc.api.v2.application.infra.entity.AnswerChoiceEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import com.ryc.api.v2.application.infra.entity.AnswerChoiceEntity;
+
 @Repository
-public interface AnswerChoiceJpaRepository extends JpaRepository<AnswerChoiceEntity, String> {
-}
+public interface AnswerChoiceJpaRepository extends JpaRepository<AnswerChoiceEntity, String> {}

--- a/server/src/main/java/com/ryc/api/v2/application/infra/jpa/AnswerJpaRepository.java
+++ b/server/src/main/java/com/ryc/api/v2/application/infra/jpa/AnswerJpaRepository.java
@@ -1,9 +1,9 @@
 package com.ryc.api.v2.application.infra.jpa;
 
-import com.ryc.api.v2.application.infra.entity.AnswerEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import com.ryc.api.v2.application.infra.entity.AnswerEntity;
+
 @Repository
-public interface AnswerJpaRepository extends JpaRepository<AnswerEntity, String> {
-}
+public interface AnswerJpaRepository extends JpaRepository<AnswerEntity, String> {}

--- a/server/src/main/java/com/ryc/api/v2/application/infra/jpa/ApplicationJpaRepository.java
+++ b/server/src/main/java/com/ryc/api/v2/application/infra/jpa/ApplicationJpaRepository.java
@@ -1,12 +1,16 @@
 package com.ryc.api.v2.application.infra.jpa;
 
-import com.ryc.api.v2.application.infra.entity.ApplicationEntity;
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import com.ryc.api.v2.application.infra.entity.ApplicationEntity;
 
 @Repository
 public interface ApplicationJpaRepository extends JpaRepository<ApplicationEntity, String> {
-    Optional<ApplicationEntity> findByApplicantId(String applicantId);
+  Optional<ApplicationEntity> findByApplicantId(String applicantId);
+
+  List<ApplicationEntity> findAllByApplicantIdIn(List<String> applicantIds);
 }

--- a/server/src/main/java/com/ryc/api/v2/application/infra/mapper/AnswerChoiceMapper.java
+++ b/server/src/main/java/com/ryc/api/v2/application/infra/mapper/AnswerChoiceMapper.java
@@ -5,20 +5,18 @@ import com.ryc.api.v2.application.infra.entity.AnswerChoiceEntity;
 import com.ryc.api.v2.application.infra.entity.AnswerEntity;
 
 public class AnswerChoiceMapper {
-    public static AnswerChoice toDomain(AnswerChoiceEntity entity) {
-        if (entity == null) return null;
-        return AnswerChoice.builder()
-                .id(entity.getId())
-                .optionId(entity.getOptionId())
-                .build();
-    }
+  public static AnswerChoice toDomain(AnswerChoiceEntity entity) {
+    if (entity == null) return null;
+    return AnswerChoice.builder().id(entity.getId()).optionId(entity.getOptionId()).build();
+  }
 
-    public static AnswerChoiceEntity toEntity(AnswerChoice domain, AnswerEntity answerEntity) {
-        if (domain == null) return null;
-        return AnswerChoiceEntity.builder()
-                .id(domain.getId())
-                .answer(answerEntity)
-                .optionId(domain.getOptionId())
-                .build();
-    }
+  public static AnswerChoiceEntity toEntity(AnswerChoice domain, AnswerEntity answerEntity) {
+    if (domain == null) return null;
+
+    return AnswerChoiceEntity.builder()
+        .id(domain.getId())
+        .answer(answerEntity)
+        .optionId(domain.getOptionId())
+        .build();
+  }
 }

--- a/server/src/main/java/com/ryc/api/v2/application/infra/mapper/AnswerMapper.java
+++ b/server/src/main/java/com/ryc/api/v2/application/infra/mapper/AnswerMapper.java
@@ -1,35 +1,48 @@
 package com.ryc.api.v2.application.infra.mapper;
 
-import com.ryc.api.v2.application.domain.Answer;
-import com.ryc.api.v2.application.infra.entity.AnswerEntity;
-import com.ryc.api.v2.application.infra.entity.ApplicationEntity;
-
-import com.ryc.api.v2.s3.infra.entity.FileMetadataEntity;
-
+import java.util.List;
 import java.util.stream.Collectors;
 
-public class AnswerMapper {
-    public static Answer toDomain(AnswerEntity entity) {
-        if (entity == null) return null;
-        return Answer.builder()
-                .id(entity.getId())
-                .questionId(entity.getQuestionId())
-                .answerText(entity.getAnswerText())
-                .choices(entity.getChoices().stream().map(AnswerChoiceMapper::toDomain).collect(Collectors.toList()))
-                .fileMetadataId(entity.getFileMetadata() != null ? entity.getFileMetadata().getId() : null)
-                .build();
-    }
+import com.ryc.api.v2.application.domain.Answer;
+import com.ryc.api.v2.application.domain.AnswerChoice;
+import com.ryc.api.v2.application.infra.entity.AnswerChoiceEntity;
+import com.ryc.api.v2.application.infra.entity.AnswerEntity;
+import com.ryc.api.v2.application.infra.entity.ApplicationEntity;
+import com.ryc.api.v2.s3.infra.entity.FileMetadataEntity;
 
-    public static AnswerEntity toEntity(Answer domain, ApplicationEntity applicationEntity, FileMetadataEntity fileMetadata) {
-        if (domain == null) return null;
-        AnswerEntity entity = AnswerEntity.builder()
-                .id(domain.getId())
-                .application(applicationEntity)
-                .questionId(domain.getQuestionId())
-                .answerText(domain.getAnswerText())
-                .fileMetadata(fileMetadata)
-                .build();
-        entity.setChoices(domain.getChoices().stream().map(choice -> AnswerChoiceMapper.toEntity(choice, entity)).collect(Collectors.toList()));
-        return entity;
-    }
+public class AnswerMapper {
+  public static Answer toDomain(AnswerEntity entity) {
+    if (entity == null) return null;
+
+    List<AnswerChoice> choices =
+        entity.getChoices().stream().map(AnswerChoiceMapper::toDomain).collect(Collectors.toList());
+
+    return Answer.builder()
+        .id(entity.getId())
+        .questionId(entity.getQuestionId())
+        .textAnswer(entity.getTextAnswer())
+        .choices(choices)
+        .fileMetadataId(entity.getFileMetadata() != null ? entity.getFileMetadata().getId() : null)
+        .build();
+  }
+
+  public static AnswerEntity toEntity(
+      Answer domain, ApplicationEntity applicationEntity, FileMetadataEntity fileMetadata) {
+    if (domain == null) return null;
+
+    AnswerEntity entity =
+        AnswerEntity.builder()
+            .id(domain.getId())
+            .application(applicationEntity)
+            .questionId(domain.getQuestionId())
+            .textAnswer(domain.getTextAnswer())
+            .fileMetadata(fileMetadata)
+            .build();
+    List<AnswerChoiceEntity> choices =
+        domain.getChoices().stream()
+            .map(choice -> AnswerChoiceMapper.toEntity(choice, entity))
+            .collect(Collectors.toList());
+    entity.setChoices(choices);
+    return entity;
+  }
 }

--- a/server/src/main/java/com/ryc/api/v2/application/infra/mapper/ApplicationMapper.java
+++ b/server/src/main/java/com/ryc/api/v2/application/infra/mapper/ApplicationMapper.java
@@ -22,11 +22,11 @@ public class ApplicationMapper {
   }
 
   public static ApplicationEntity toEntity(
-      Application domain, Map<String, FileMetadataEntity> fileMetadataMap) {
+      Application domain, Map<String, FileMetadataEntity> fileMetadataMap, String applicantId) {
     if (domain == null) return null;
 
     ApplicationEntity entity =
-        ApplicationEntity.builder().id(domain.getId()).applicantId(domain.getApplicantId()).build();
+        ApplicationEntity.builder().id(domain.getId()).applicantId(applicantId).build();
 
     List<AnswerEntity> answers =
         domain.getAnswers().stream()

--- a/server/src/main/java/com/ryc/api/v2/application/infra/mapper/ApplicationMapper.java
+++ b/server/src/main/java/com/ryc/api/v2/application/infra/mapper/ApplicationMapper.java
@@ -1,32 +1,42 @@
 package com.ryc.api.v2.application.infra.mapper;
 
-import com.ryc.api.v2.application.domain.Application;
-import com.ryc.api.v2.application.infra.entity.ApplicationEntity;
-
-import com.ryc.api.v2.s3.infra.entity.FileMetadataEntity;
-
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public class ApplicationMapper {
-    public static Application toDomain(ApplicationEntity entity) {
-        if (entity == null) return null;
-        return Application.builder()
-                .id(entity.getId())
-                .applicantId(entity.getApplicantId())
-                .answers(entity.getAnswers().stream().map(AnswerMapper::toDomain).collect(Collectors.toList()))
-                .createdAt(entity.getCreatedAt())
-                .updatedAt(entity.getUpdatedAt())
-                .build();
-    }
+import com.ryc.api.v2.application.domain.Application;
+import com.ryc.api.v2.application.infra.entity.AnswerEntity;
+import com.ryc.api.v2.application.infra.entity.ApplicationEntity;
+import com.ryc.api.v2.s3.infra.entity.FileMetadataEntity;
 
-    public static ApplicationEntity toEntity(Application domain, Map<String, FileMetadataEntity> fileMetadataMap) {
-        if (domain == null) return null;
-        ApplicationEntity entity = ApplicationEntity.builder()
-                .id(domain.getId())
-                .applicantId(domain.getApplicantId())
-                .build();
-        entity.setAnswers(domain.getAnswers().stream().map(answer -> AnswerMapper.toEntity(answer, entity, fileMetadataMap.get(answer.getFileMetadataId()))).collect(Collectors.toList()));
-        return entity;
-    }
+public class ApplicationMapper {
+  public static Application toDomain(ApplicationEntity entity) {
+    if (entity == null) return null;
+    return Application.builder()
+        .id(entity.getId())
+        .applicantId(entity.getApplicantId())
+        .answers(
+            entity.getAnswers().stream().map(AnswerMapper::toDomain).collect(Collectors.toList()))
+        .createdAt(entity.getCreatedAt())
+        .build();
+  }
+
+  public static ApplicationEntity toEntity(
+      Application domain, Map<String, FileMetadataEntity> fileMetadataMap) {
+    if (domain == null) return null;
+
+    ApplicationEntity entity =
+        ApplicationEntity.builder().id(domain.getId()).applicantId(domain.getApplicantId()).build();
+
+    List<AnswerEntity> answers =
+        domain.getAnswers().stream()
+            .map(
+                answer ->
+                    AnswerMapper.toEntity(
+                        answer, entity, fileMetadataMap.get(answer.getFileMetadataId())))
+            .collect(Collectors.toList());
+    entity.setAnswers(answers);
+
+    return entity;
+  }
 }

--- a/server/src/main/java/com/ryc/api/v2/application/presentation/ApplicationHttpApi.java
+++ b/server/src/main/java/com/ryc/api/v2/application/presentation/ApplicationHttpApi.java
@@ -1,0 +1,96 @@
+package com.ryc.api.v2.application.presentation;
+
+import java.util.List;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.ryc.api.v2.application.presentation.dto.request.ApplicationSubmissionRequest;
+import com.ryc.api.v2.application.presentation.dto.response.ApplicationGetResponse;
+import com.ryc.api.v2.application.presentation.dto.response.ApplicationSubmissionResponse;
+import com.ryc.api.v2.application.presentation.dto.response.ApplicationSummaryResponse;
+import com.ryc.api.v2.common.exception.response.ErrorResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@RequestMapping("/api/v2/announcements/{announcement-id}/applications")
+@Tag(name = "지원")
+public interface ApplicationHttpApi {
+
+  @PostMapping
+  @Operation(summary = "공고 지원", operationId = "submitApplication")
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            responseCode = "201",
+            description = "Created",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ApplicationSubmissionResponse.class)),
+            headers = {@Header(name = "Location", description = "생성된 리소스의 상세정보 조회 URI")}),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Bad Request",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(
+            responseCode = "404",
+            description = "존재하지 않는 공고입니다.",
+            content = @Content(schema = @Schema(hidden = true))),
+        @ApiResponse(
+            responseCode = "409",
+            description = "비즈니스 로직에 맞지 않는 요청입니다.",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+      })
+  ResponseEntity<ApplicationSubmissionResponse> submitApplication(
+      @PathVariable("announcement-id") String announcementId,
+      @Valid @RequestBody ApplicationSubmissionRequest body);
+
+  @GetMapping
+  @Operation(summary = "공고 지원서 목록 조회", operationId = "getApplications")
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "OK",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ApplicationSummaryResponse.class))),
+        @ApiResponse(
+            responseCode = "404",
+            description = "존재하지 않는 공고입니다.",
+            content = @Content(schema = @Schema(hidden = true)))
+      })
+  ResponseEntity<List<ApplicationSummaryResponse>> getApplicationsByAnnouncementId(
+      @PathVariable("announcement-id") String announcementId,
+      @RequestParam(value = "status", required = false) String status);
+
+  @GetMapping("/{applicant-id}")
+  @Operation(summary = "지원서 상세 조회", operationId = "getApplicationDetail")
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "OK",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ApplicationGetResponse.class))),
+        @ApiResponse(
+            responseCode = "404",
+            description = "존재하지 않는 공고 또는 지원자입니다.",
+            content = @Content(schema = @Schema(hidden = true)))
+      })
+  ResponseEntity<ApplicationGetResponse> getApplicationDetail(
+      @PathVariable("announcement-id") String announcementId,
+      @PathVariable("applicant-id") String applicantId);
+}

--- a/server/src/main/java/com/ryc/api/v2/application/presentation/ApplicationHttpApiImpl.java
+++ b/server/src/main/java/com/ryc/api/v2/application/presentation/ApplicationHttpApiImpl.java
@@ -1,0 +1,53 @@
+package com.ryc.api.v2.application.presentation;
+
+import java.net.URI;
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ryc.api.v2.application.presentation.dto.request.ApplicationSubmissionRequest;
+import com.ryc.api.v2.application.presentation.dto.response.ApplicationGetResponse;
+import com.ryc.api.v2.application.presentation.dto.response.ApplicationSubmissionResponse;
+import com.ryc.api.v2.application.presentation.dto.response.ApplicationSummaryResponse;
+import com.ryc.api.v2.application.service.ApplicationService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class ApplicationHttpApiImpl implements ApplicationHttpApi {
+  private final ApplicationService applicationService;
+
+  @Override
+  public ResponseEntity<ApplicationSubmissionResponse> submitApplication(
+      String announcementId, ApplicationSubmissionRequest body) {
+    ApplicationSubmissionResponse response =
+        applicationService.submitApplication(body, announcementId);
+
+    URI location =
+        URI.create(
+            String.format(
+                "/api/v2/announcements/%s/applications/%s",
+                announcementId, response.applicationId()));
+    return ResponseEntity.created(location).body(response);
+  }
+
+  @Override
+  // TODO: @HasRole(Role.MEMBER)
+  public ResponseEntity<List<ApplicationSummaryResponse>> getApplicationsByAnnouncementId(
+      String announcementId, String status) {
+    List<ApplicationSummaryResponse> response =
+        applicationService.getApplicationsByAnnouncementId(announcementId, status);
+    return ResponseEntity.ok(response);
+  }
+
+  @Override
+  // TODO:@HasRole(Role.MEMBER)
+  public ResponseEntity<ApplicationGetResponse> getApplicationDetail(
+      String announcementId, String applicantId) {
+    ApplicationGetResponse response =
+        applicationService.getApplicationDetail(announcementId, applicantId);
+    return ResponseEntity.ok(response);
+  }
+}

--- a/server/src/main/java/com/ryc/api/v2/application/presentation/dto/request/AnswerChoiceCreateRequest.java
+++ b/server/src/main/java/com/ryc/api/v2/application/presentation/dto/request/AnswerChoiceCreateRequest.java
@@ -1,0 +1,9 @@
+package com.ryc.api.v2.application.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+import lombok.Builder;
+
+@Builder
+public record AnswerChoiceCreateRequest(
+    @NotBlank(message = "optionId shouldn't be blank") String optionId) {}

--- a/server/src/main/java/com/ryc/api/v2/application/presentation/dto/request/AnswerCreateRequest.java
+++ b/server/src/main/java/com/ryc/api/v2/application/presentation/dto/request/AnswerCreateRequest.java
@@ -1,0 +1,24 @@
+package com.ryc.api.v2.application.presentation.dto.request;
+
+import java.util.List;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+import lombok.Builder;
+
+@Builder
+public record AnswerCreateRequest(
+    @NotNull(message = "questionId shouldn't be null") String questionId,
+    String textAnswer,
+    String fileMetadataId,
+    List<@Valid AnswerChoiceCreateRequest> answerChoices) {
+  public AnswerCreateRequest {
+    answerChoices = answerChoices == null ? List.of() : answerChoices;
+  }
+
+  @Override
+  public List<AnswerChoiceCreateRequest> answerChoices() {
+    return List.copyOf(answerChoices);
+  }
+}

--- a/server/src/main/java/com/ryc/api/v2/application/presentation/dto/request/ApplicationCreateRequest.java
+++ b/server/src/main/java/com/ryc/api/v2/application/presentation/dto/request/ApplicationCreateRequest.java
@@ -1,0 +1,19 @@
+package com.ryc.api.v2.application.presentation.dto.request;
+
+import java.util.List;
+
+import jakarta.validation.Valid;
+
+import lombok.Builder;
+
+@Builder
+public record ApplicationCreateRequest(List<@Valid AnswerCreateRequest> answers) {
+  public ApplicationCreateRequest {
+    answers = answers == null ? List.of() : answers;
+  }
+
+  @Override
+  public List<AnswerCreateRequest> answers() {
+    return List.copyOf(answers);
+  }
+}

--- a/server/src/main/java/com/ryc/api/v2/application/presentation/dto/request/ApplicationSubmissionRequest.java
+++ b/server/src/main/java/com/ryc/api/v2/application/presentation/dto/request/ApplicationSubmissionRequest.java
@@ -1,0 +1,14 @@
+package com.ryc.api.v2.application.presentation.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+import com.ryc.api.v2.applicant.presentation.dto.request.ApplicantCreateRequest;
+
+import lombok.Builder;
+
+@Builder
+public record ApplicationSubmissionRequest(
+    @NotNull(message = "applicant shouldn't be null") @Valid ApplicantCreateRequest applicant,
+    @NotNull(message = "application shouldn't be null") @Valid
+        ApplicationCreateRequest application) {}

--- a/server/src/main/java/com/ryc/api/v2/application/presentation/dto/response/AnswerChoiceResponse.java
+++ b/server/src/main/java/com/ryc/api/v2/application/presentation/dto/response/AnswerChoiceResponse.java
@@ -1,0 +1,19 @@
+package com.ryc.api.v2.application.presentation.dto.response;
+
+import com.ryc.api.v2.application.domain.AnswerChoice;
+import com.ryc.api.v2.applicationForm.domain.QuestionOption;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record AnswerChoiceResponse(
+    @Schema(description = "선택지 ID", example = "uuid-option-1") String optionId,
+    @Schema(description = "선택지 내용", example = "Java") String optionLabel) {
+  public static AnswerChoiceResponse of(AnswerChoice choice, QuestionOption option) {
+    return AnswerChoiceResponse.builder()
+        .optionId(choice.getOptionId())
+        .optionLabel(option.getOption())
+        .build();
+  }
+}

--- a/server/src/main/java/com/ryc/api/v2/application/presentation/dto/response/AnswerResponse.java
+++ b/server/src/main/java/com/ryc/api/v2/application/presentation/dto/response/AnswerResponse.java
@@ -1,0 +1,41 @@
+package com.ryc.api.v2.application.presentation.dto.response;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.ryc.api.v2.application.domain.Answer;
+import com.ryc.api.v2.applicationForm.domain.Question;
+import com.ryc.api.v2.applicationForm.domain.QuestionOption;
+import com.ryc.api.v2.applicationForm.domain.enums.QuestionType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record AnswerResponse(
+    @Schema(description = "질문 ID", example = "uuid-question-1") String questionId,
+    @Schema(description = "질문 내용", example = "자기소개를 해주세요.") String questionLabel,
+    @Schema(description = "질문 유형", example = "LONG_ANSWER") QuestionType questionType,
+    @Schema(description = "서술형 답변", example = "안녕하세요...") String textAnswer,
+    @Schema(description = "선택형 답변") List<AnswerChoiceResponse> choices,
+    @Schema(description = "첨부 파일 URL", example = "https://.../file.pdf")
+        String fileUrl // TODO: S3 연동 후 실제 URL 매핑 필요
+    ) {
+  public static AnswerResponse of(
+      Answer answer, Question question, Map<String, QuestionOption> optionMap) {
+    List<AnswerChoiceResponse> choiceResponses =
+        answer.getChoices().stream()
+            .map(choice -> AnswerChoiceResponse.of(choice, optionMap.get(choice.getOptionId())))
+            .collect(Collectors.toList());
+
+    return AnswerResponse.builder()
+        .questionId(answer.getQuestionId())
+        .questionLabel(question.getLabel())
+        .questionType(question.getQuestionType())
+        .textAnswer(answer.getTextAnswer())
+        .choices(choiceResponses)
+        .fileUrl(null) // TODO: S3 연동
+        .build();
+  }
+}

--- a/server/src/main/java/com/ryc/api/v2/application/presentation/dto/response/ApplicantPersonalInfoResponse.java
+++ b/server/src/main/java/com/ryc/api/v2/application/presentation/dto/response/ApplicantPersonalInfoResponse.java
@@ -1,0 +1,20 @@
+package com.ryc.api.v2.application.presentation.dto.response;
+
+import com.ryc.api.v2.applicant.domain.ApplicantPersonalInfo;
+import com.ryc.api.v2.applicationForm.domain.enums.PersonalInfoQuestionType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record ApplicantPersonalInfoResponse(
+    @Schema(description = "개인정보 질문 유형", example = "STUDENT_ID")
+        PersonalInfoQuestionType questionType,
+    @Schema(description = "답변 내용", example = "202012345") String value) {
+  public static ApplicantPersonalInfoResponse from(ApplicantPersonalInfo personalInfo) {
+    return ApplicantPersonalInfoResponse.builder()
+        .questionType(personalInfo.getQuestionType())
+        .value(personalInfo.getValue())
+        .build();
+  }
+}

--- a/server/src/main/java/com/ryc/api/v2/application/presentation/dto/response/ApplicationGetResponse.java
+++ b/server/src/main/java/com/ryc/api/v2/application/presentation/dto/response/ApplicationGetResponse.java
@@ -1,0 +1,67 @@
+package com.ryc.api.v2.application.presentation.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.ryc.api.v2.applicant.domain.Applicant;
+import com.ryc.api.v2.applicant.domain.enums.ApplicantStatus;
+import com.ryc.api.v2.application.domain.Application;
+import com.ryc.api.v2.applicationForm.domain.ApplicationForm;
+import com.ryc.api.v2.applicationForm.domain.Question;
+import com.ryc.api.v2.applicationForm.domain.QuestionOption;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record ApplicationGetResponse(
+    @Schema(description = "지원자 ID", example = "2ef2b4c5c-8d4c-4c4c-8d4c-2eef2b4c5c4c")
+        String applicantId,
+    @Schema(description = "지원자 이름", example = "홍길동") String name,
+    @Schema(description = "지원자 이메일", example = "gildong@example.com") String email,
+    @Schema(description = "지원 상태", example = "PENDING") ApplicantStatus status,
+    @Schema(description = "제출 일시", example = "2025-07-22T10:00:00") LocalDateTime submittedAt,
+    @Schema(description = "추가 개인정보 목록") List<ApplicantPersonalInfoResponse> personalInfos,
+    @Schema(description = "답변 목록") List<AnswerResponse> answers) {
+  public static ApplicationGetResponse of(
+      Applicant applicant, Application application, ApplicationForm applicationForm) {
+    List<ApplicantPersonalInfoResponse> personalInfoResponses =
+        applicant.getPersonalInfos().stream()
+            .map(ApplicantPersonalInfoResponse::from)
+            .collect(Collectors.toList());
+
+    Map<String, Question> questionMap =
+        Stream.concat(
+                applicationForm.getApplicationQuestions().stream(),
+                applicationForm.getPreQuestions().stream())
+            .collect(Collectors.toMap(Question::getId, Function.identity()));
+
+    Map<String, QuestionOption> optionMap =
+        Stream.concat(
+                applicationForm.getApplicationQuestions().stream(),
+                applicationForm.getPreQuestions().stream())
+            .flatMap(q -> q.getOptions().stream())
+            .collect(Collectors.toMap(QuestionOption::getId, Function.identity()));
+
+    List<AnswerResponse> answerResponses =
+        application.getAnswers().stream()
+            .map(
+                answer ->
+                    AnswerResponse.of(answer, questionMap.get(answer.getQuestionId()), optionMap))
+            .collect(Collectors.toList());
+
+    return ApplicationGetResponse.builder()
+        .applicantId(applicant.getId())
+        .name(applicant.getName())
+        .email(applicant.getEmail())
+        .status(applicant.getStatus())
+        .submittedAt(application.getCreatedAt()) // Assuming Application has createdAt
+        .personalInfos(personalInfoResponses)
+        .answers(answerResponses)
+        .build();
+  }
+}

--- a/server/src/main/java/com/ryc/api/v2/application/presentation/dto/response/ApplicationSubmissionResponse.java
+++ b/server/src/main/java/com/ryc/api/v2/application/presentation/dto/response/ApplicationSubmissionResponse.java
@@ -1,0 +1,19 @@
+package com.ryc.api.v2.application.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record ApplicationSubmissionResponse(
+    @Schema(description = "지원자 ID", example = "e2a1b7b4-6c6e-4d2a-8f8b-0b8b8b8b8b8b")
+        String applicantId,
+    @Schema(description = "지원-ID", example = "e2a1b7b4-6c6e-4d2a-8f8b-0b8b8b8b8b8b")
+        String applicationId) {
+
+  public static ApplicationSubmissionResponse of(String applicantId, String applciationId) {
+    return ApplicationSubmissionResponse.builder()
+        .applicantId(applicantId)
+        .applicationId(applciationId)
+        .build();
+  }
+}

--- a/server/src/main/java/com/ryc/api/v2/application/presentation/dto/response/ApplicationSummaryResponse.java
+++ b/server/src/main/java/com/ryc/api/v2/application/presentation/dto/response/ApplicationSummaryResponse.java
@@ -1,0 +1,27 @@
+package com.ryc.api.v2.application.presentation.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.ryc.api.v2.applicant.domain.Applicant;
+import com.ryc.api.v2.applicant.domain.enums.ApplicantStatus;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record ApplicationSummaryResponse(
+    @Schema(description = "지원자 ID", example = "uuid-applicant-1") String applicantId,
+    @Schema(description = "지원자 이름", example = "홍길동") String name,
+    @Schema(description = "지원자 이메일", example = "gildong@example.com") String email,
+    @Schema(description = "지원 상태", example = "PENDING") ApplicantStatus status,
+    @Schema(description = "제출 일시", example = "2025-07-22T10:00:00") LocalDateTime submittedAt) {
+  public static ApplicationSummaryResponse of(Applicant applicant, LocalDateTime submittedAt) {
+    return ApplicationSummaryResponse.builder()
+        .applicantId(applicant.getId())
+        .name(applicant.getName())
+        .email(applicant.getEmail())
+        .status(applicant.getStatus())
+        .submittedAt(submittedAt)
+        .build();
+  }
+}

--- a/server/src/main/java/com/ryc/api/v2/application/service/ApplicationService.java
+++ b/server/src/main/java/com/ryc/api/v2/application/service/ApplicationService.java
@@ -59,7 +59,6 @@ public class ApplicationService {
     Applicant savedApplicant = applicantRepository.save(applicant);
 
     // 4. 지원서 객체 생성 및 비즈니스 룰 검사
-
     Application application =
         Application.initialize(applicationSubmissionRequest.application(), applicant.getId());
 

--- a/server/src/main/java/com/ryc/api/v2/application/service/ApplicationService.java
+++ b/server/src/main/java/com/ryc/api/v2/application/service/ApplicationService.java
@@ -103,9 +103,7 @@ public class ApplicationService {
   @Transactional(readOnly = true)
   public ApplicationGetResponse getApplicationDetail(String announcementId, String applicantId) {
     // 1. 지원자 조회
-    Applicant applicant =
-        applicantRepository
-            .findById(applicantId);
+    Applicant applicant = applicantRepository.findById(applicantId);
 
     // 2. 지원서 조회
     Application application = applicationRepository.findByApplicantId(applicant.getId());

--- a/server/src/main/java/com/ryc/api/v2/application/service/ApplicationService.java
+++ b/server/src/main/java/com/ryc/api/v2/application/service/ApplicationService.java
@@ -1,0 +1,120 @@
+package com.ryc.api.v2.application.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ryc.api.v2.announcement.domain.Announcement;
+import com.ryc.api.v2.announcement.domain.AnnouncementRepository;
+import com.ryc.api.v2.announcement.domain.enums.AnnouncementStatus;
+import com.ryc.api.v2.applicant.domain.Applicant;
+import com.ryc.api.v2.applicant.domain.ApplicantRepository;
+import com.ryc.api.v2.applicant.domain.enums.ApplicantStatus;
+import com.ryc.api.v2.application.common.exception.code.ApplicationCreateErrorCode;
+import com.ryc.api.v2.application.domain.Application;
+import com.ryc.api.v2.application.domain.ApplicationRepository;
+import com.ryc.api.v2.application.presentation.dto.request.ApplicationSubmissionRequest;
+import com.ryc.api.v2.application.presentation.dto.response.ApplicationGetResponse;
+import com.ryc.api.v2.application.presentation.dto.response.ApplicationSubmissionResponse;
+import com.ryc.api.v2.application.presentation.dto.response.ApplicationSummaryResponse;
+import com.ryc.api.v2.applicationForm.domain.ApplicationForm;
+import com.ryc.api.v2.applicationForm.domain.ApplicationFormRepository;
+import com.ryc.api.v2.common.exception.custom.BusinessRuleException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ApplicationService {
+
+  private final AnnouncementRepository announcementRepository;
+  private final ApplicationRepository applicationRepository;
+  private final ApplicantRepository applicantRepository;
+  private final ApplicationFormRepository applicationFormRepository;
+
+  @Transactional
+  public ApplicationSubmissionResponse submitApplication(
+      ApplicationSubmissionRequest applicationSubmissionRequest, String announcementId) {
+    // 1. 공고 조회
+    Announcement announcement = announcementRepository.findById(announcementId);
+
+    // 2. 공고 모집중 확인
+    if (announcement.getAnnouncementStatus() != AnnouncementStatus.RECRUITING) {
+      throw new BusinessRuleException(ApplicationCreateErrorCode.ANNOUNCEMENT_NOT_RECRUITING);
+    }
+
+    // 3. 지원, 지원자 도메인 객체 생성
+    Application application = Application.initialize(applicationSubmissionRequest.application());
+    Applicant applicant =
+        Applicant.initialize(applicationSubmissionRequest.applicant(), announcementId);
+
+    // 4. 비즈니스 룰 검사
+    applicant.checkBusinessRules(announcement.getApplicationForm());
+    application.validate(announcement.getApplicationForm());
+
+    Applicant savedApplicant = applicantRepository.save(applicant);
+    application.assignApplicantId(savedApplicant.getId());
+    Application savedApplication = applicationRepository.save(application);
+
+    return ApplicationSubmissionResponse.of(savedApplicant.getId(), savedApplication.getId());
+  }
+
+  @Transactional(readOnly = true)
+  public List<ApplicationSummaryResponse> getApplicationsByAnnouncementId(
+      String announcementId, String status) {
+    List<Applicant> applicants;
+
+    // 1. status 변환
+    ApplicantStatus applicantStatus = ApplicantStatus.from(status);
+
+    // 2. status에 따른 공고 조회
+    if (applicantStatus == null) {
+      applicants = applicantRepository.findAllByAnnouncementId(announcementId);
+    } else {
+      applicants =
+          applicantRepository.findAllByAnnouncementIdAndStatus(announcementId, applicantStatus);
+    }
+    // 3. 해당 공고의 모든 지원자 조회
+    if (applicants.isEmpty()) {
+      return List.of();
+    }
+
+    // 4. 모든 지원자의 지원서를 한번에 조회 (N+1 방지)
+    List<String> applicantIds = applicants.stream().map(Applicant::getId).toList();
+    Map<String, Application> applicationMap =
+        applicationRepository.findAllByApplicantIdIn(applicantIds).stream()
+            .collect(Collectors.toMap(Application::getApplicantId, Function.identity()));
+
+    // 5. DTO로 조립
+    return applicants.stream()
+        .map(
+            applicant -> {
+              Application application = applicationMap.get(applicant.getId());
+              // submittedAt은 application 객체에서 가져옴
+              return ApplicationSummaryResponse.of(applicant, application.getCreatedAt());
+            })
+        .collect(Collectors.toList());
+  }
+
+  @Transactional(readOnly = true)
+  public ApplicationGetResponse getApplicationDetail(String announcementId, String applicantId) {
+    // 1. 지원자 조회
+    Applicant applicant =
+        applicantRepository
+            .findById(applicantId);
+
+    // 2. 지원서 조회
+    Application application = applicationRepository.findByApplicantId(applicant.getId());
+
+    // 3. 지원서 양식 조회
+    ApplicationForm applicationForm =
+        applicationFormRepository.findByAnnouncementId(announcementId);
+
+    // 4. DTO로 조립
+    return ApplicationGetResponse.of(applicant, application, applicationForm);
+  }
+}

--- a/server/src/main/java/com/ryc/api/v2/applicationForm/domain/ApplicationForm.java
+++ b/server/src/main/java/com/ryc/api/v2/applicationForm/domain/ApplicationForm.java
@@ -78,12 +78,12 @@ public class ApplicationForm {
   public void checkBusinessRules() {
     validatePersonalInfoQuestionTypes();
 
-    // 각 ApplicationQuestion 객체의 validate
+    // 각 ApplicationQuestion 객체의 checkBusinessRules
     for (Question question : applicationQuestions) {
       question.checkBusinessRules();
     }
 
-    // 각 preQuestion 객체의 validate
+    // 각 preQuestion 객체의 checkBusinessRules
     for (Question question : preQuestions) {
       question.checkBusinessRules();
     }

--- a/server/src/main/java/com/ryc/api/v2/applicationForm/domain/ApplicationForm.java
+++ b/server/src/main/java/com/ryc/api/v2/applicationForm/domain/ApplicationForm.java
@@ -20,9 +20,9 @@ import lombok.Getter;
 public class ApplicationForm {
   private final String id;
 
-  private List<Question> applicationQuestions;
-  private List<PersonalInfoQuestionType> personalInfoQuestionTypes;
-  private List<Question> preQuestions;
+  private final List<Question> applicationQuestions;
+  private final List<PersonalInfoQuestionType> personalInfoQuestionTypes;
+  private final List<Question> preQuestions;
 
   /**
    * @param request create request

--- a/server/src/main/java/com/ryc/api/v2/applicationForm/domain/Question.java
+++ b/server/src/main/java/com/ryc/api/v2/applicationForm/domain/Question.java
@@ -18,7 +18,7 @@ import lombok.Getter;
 public class Question {
   private final String id;
   private final String label;
-  private boolean isRequired;
+  private final boolean isRequired;
 
   private final List<QuestionOption> options;
 


### PR DESCRIPTION
## 📌 관련 이슈
#231 #230 


## 🛠️ 작업 내용
PR에서 작업한 주요 내용을 적어주세요.
- [ ] 지원서 제출 API 구현
- [ ] 지원서 목록 조회 API 구현
- [ ] 지원서 상세 조회 API 구현

## 🎯 리뷰 포인트
1. erd 변경점
```
applicants의 application 시에 입력받는 개인정보(personal_info)를 저장할 테이블을 추가하였습니다.
기존에는 Answer 객체에서 통합적으로 관리하려 했으나 
- Answer 객체는 `Question`과 강한 결합도를 가지고 있지만 `Personal_info` enum 객체와는 연관성이 없기에 같이 관리될 경우 불필요한 연관관계 형성
- `Application`, `Applicant` 도메인이 분리되어 있어 상대적으로 `Answer`객체는 `Application` 개인정보는 `Applicant`객체와 연관성이 높다고 판단함

위와 같은 이유로 테이블을 따로 분리하여 관리하게 설계 하였습니다.
```
<img width="793" height="482" alt="image" src="https://github.com/user-attachments/assets/fefd5be6-7d2b-4bc0-9bf4-e07111c585c7" />

2. 지원 도메인 조회시 파라미터 값에 대해
```
지원서 조회시 엔드포인트 설정을 현재는 `announcements/{announcement-id}/applications/{applicant-id}` 와 같이 설정 되어있습니다. 제가 고민했던 다른 하나의 엔드포인트는 {applicant-id}가 아닌 {application-id}를 입력받는 형태 입니다.
해당 방안이 가장 일반적이라 생각은 하나, 해당 지원자의 지원서를 조회한다는 API라 제 생각에는 전자가 더욱 부합하다 생각하여 전자를 택하였으나 다른 API 엔드포인트와의 통일성이 떨어지는 단점도 존재한다 생각하여 다른 분들의 의견을 들어보고 싶습니다.
```

## ⏳ 작업 시간
추정 시간:   
실제 시간:   
이유: 차이가 많이 난다면 이유도 같이 적어주세요 :)
