### PR TITLE
[BE] Path 패턴 매칭 수정

### DIFF
--- a/server/src/main/java/com/ryc/api/config/SwaggerConfiguration.java
+++ b/server/src/main/java/com/ryc/api/config/SwaggerConfiguration.java
@@ -1,13 +1,13 @@
 package com.ryc.api.config;
 
 import java.util.*;
+import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 
 import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.util.AntPathMatcher;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.method.HandlerMethod;
 
@@ -49,32 +49,26 @@ public class SwaggerConfiguration {
    */
   private record ExampleResponse(String name, ApiResponse item) {}
 
-  private final AntPathMatcher antPathMatcher = new AntPathMatcher();
-  private final Set<String> whitelistAllPaths;
-  private final Set<String> whitelistGetPaths;
-  private final Set<String> whitelistPostPaths;
+  private final Set<String> whitelistGetPatterns;
+  private final Set<String> whitelistPostPatterns;
 
   /*
    * SwaggerConfiguration 생성자입니다.
    * 이 생성자는 애플리케이션 설정 파일에서 화이트리스트 경로를 읽어와
    * 각 경로를 슬래시("/")로 시작하도록 보장합니다.
+   * 각 경로의 변수 부분은 더미 UUID로 대체하여
+   * Swagger 문서에서 일관된 예시를 제공합니다.
    */
   public SwaggerConfiguration(
-      @Value("${SECURITY_WHITELIST_ALL_METHOD_PATHS}") String[] whitelistAllPaths,
-      @Value("${SECURITY_WHITELIST_GET_METHOD_PATHS}") String[] whitelistGetPaths,
-      @Value("${SECURITY_WHITELIST_POST_METHOD_PATHS}") String[] whitelistPostPaths) {
-    this.whitelistAllPaths =
-        Arrays.stream(whitelistAllPaths)
+      @Value("${SECURITY_WHITELIST_GET_METHOD_PATHS}") String[] whitelistGetPatterns,
+      @Value("${SECURITY_WHITELIST_POST_METHOD_PATHS}") String[] whitelistPostPatterns) {
+    this.whitelistGetPatterns =
+        Arrays.stream(whitelistGetPatterns)
             .map(path -> path.startsWith("/") ? path : "/" + path)
             .collect(Collectors.toSet());
 
-    this.whitelistGetPaths =
-        Arrays.stream(whitelistGetPaths)
-            .map(path -> path.startsWith("/") ? path : "/" + path)
-            .collect(Collectors.toSet());
-
-    this.whitelistPostPaths =
-        Arrays.stream(whitelistPostPaths)
+    this.whitelistPostPatterns =
+        Arrays.stream(whitelistPostPatterns)
             .map(path -> path.startsWith("/") ? path : "/" + path)
             .collect(Collectors.toSet());
   }
@@ -185,7 +179,13 @@ public class SwaggerConfiguration {
       return classPath.startsWith("/") ? classPath : "/" + classPath;
     }
 
-    String path = (classPath + "/" + methodPath[0]).replaceAll("//+", "/");
+    String path =
+        (classPath + "/" + methodPath[0])
+            .replaceAll("//+", "/")
+            .replaceAll(
+                "\\{[^}]+\\}",
+                Matcher.quoteReplacement(
+                    "123e4567-e89b-12d3-a456-426614174000")); // {id} 변수를 UUID 더미로 대체
     return path.startsWith("/") ? path : "/" + path;
   }
 
@@ -195,21 +195,15 @@ public class SwaggerConfiguration {
   private boolean isWhitelistPath(HttpOperation httpOperation) {
     String path = httpOperation.path();
 
-    for (String whitePath : whitelistAllPaths) {
-      if (antPathMatcher.match(whitePath, path)) {
-        return true;
-      }
-    }
-
     if (httpOperation.method().equals("GET")) {
-      for (String whitePath : whitelistGetPaths) {
-        if (antPathMatcher.match(whitePath, path)) {
+      for (String pattern : whitelistGetPatterns) {
+        if (path.matches(pattern)) {
           return true;
         }
       }
     } else if (httpOperation.method().equals("POST")) {
-      for (String whitePath : whitelistPostPaths) {
-        if (antPathMatcher.match(whitePath, path)) {
+      for (String pattern : whitelistPostPatterns) {
+        if (path.matches(pattern)) {
           return true;
         }
       }


### PR DESCRIPTION
## 📌 관련 이슈
close #309 

## 🛠️ 작업 내용
- [ ] `properties`에 `white list path`를 정규 표현식으로 수정
- [ ] `SecurityConfiguration`에서 해당 정규 표현식을 인식할 수 있도록 수정
- [ ] `SwaggerConfiguration`에서 해당 정규 표현식을 인식할 수 있도록 수정

## 🎯 리뷰 포인트
기존에 문제점은 다음과 같다.
`api/v2/clubs/{id}`는 인증이 필요하지 않은 API, 즉 비로그인자도 수행할 수 있는 API이다.
하지만 `api/v2/clubs/my`는 인증이 필요한 API이지만 `white list`에 와일드 카드를 삽입`(api/v2/clubs/*)`함으로써
`api/v2/clubs/{id}`와 `api/v2/clubs/my`가 매칭 되는 문제가 발생하였다.
따라서 `white list`에 와일드카드를 제거하고 정규표현식을 삽입하였다.

## FIX 결과
<img width="1048" height="118" alt="image" src="https://github.com/user-attachments/assets/5a3be4c5-b721-4d1e-ac54-cc2fc332d649" />