### PR TITLE
[BE/HOTFIX] 개발환경 Refresh Token 테스트를 위한, CORS 재설정 및 RT쿠키 설정 완화

### DIFF
--- a/server/src/main/java/com/ryc/api/v2/auth/presentation/AuthController.java
+++ b/server/src/main/java/com/ryc/api/v2/auth/presentation/AuthController.java
@@ -49,7 +49,7 @@ public class AuthController {
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 
-  @GetMapping("/refreshToken")
+  @GetMapping("/refresh-token")
   @ApiErrorCodeExample(
       value = {CommonErrorCode.class},
       include = {"RESOURCE_NOT_FOUND"})
@@ -60,7 +60,7 @@ public class AuthController {
     ResponseCookie cookie =
         ResponseCookie.from("refresh-token", refreshResult.refreshToken())
             .httpOnly(true)
-            .secure(false)
+            .secure(true)
             .path("/api/v2/auth")
             .maxAge(jwtProperties.getRefreshToken().getExpirationMinute() * 60L)
             .sameSite("None")

--- a/server/src/main/java/com/ryc/api/v2/security/filter/EmailPasswordAuthenticationFilter.java
+++ b/server/src/main/java/com/ryc/api/v2/security/filter/EmailPasswordAuthenticationFilter.java
@@ -108,7 +108,7 @@ public class EmailPasswordAuthenticationFilter extends UsernamePasswordAuthentic
     ResponseCookie cookie =
         ResponseCookie.from("refresh-token", refreshToken)
             .httpOnly(true)
-            .secure(false)
+            .secure(true)
             .path("/api/v2/auth")
             .maxAge(jwtProperties.getRefreshToken().getExpirationMinute() * 60L)
             .sameSite("None")


### PR DESCRIPTION
## 📌 관련 이슈
closed #328 

## 🛠️ 작업 내용
현재 로컬 클라이언트에서 RT쿠키를 전송하기 위해, 임시로 SameSite=None; Secure=false 설정을 해주었지만, 크롬 보안정책에 의해 쿠키가 저장되지 않고 새로고침시 삭제되는 현상발생

로컬 클라이언트 환경을 로컬 개발 서버를 HTTPS로 실행시키고 SameSite=None; Secure=true 설정으로 임시 테스트를 진행하고자 함.
프로덕션 서버 배포 이전 수정 예정

## ⏳ 작업 시간
추정 시간:   15분
실제 시간:   15분
