### PR TITLE
[BE] Not Found 예외 처리 수정

### DIFF
--- a/server/src/main/java/com/ryc/api/v1/club/service/ClubServiceImpl.java
+++ b/server/src/main/java/com/ryc/api/v1/club/service/ClubServiceImpl.java
@@ -4,8 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-import jakarta.persistence.EntityNotFoundException;
-
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.security.core.Authentication;
@@ -115,7 +113,7 @@ public class ClubServiceImpl implements ClubService {
   public List<ClubOverviewResponse> findAllClubsOverview() {
     List<Club> clubs = clubRepository.findAllWithCategories();
 
-    if (clubs.isEmpty()) throw new EntityNotFoundException("Club not found");
+    if (clubs.isEmpty()) throw new NoSuchElementException("Club not found");
 
     List<ClubOverviewResponse> responses = new ArrayList<>();
     for (Club club : clubs) {

--- a/server/src/main/java/com/ryc/api/v2/announcement/infra/AnnouncementRepositoryImpl.java
+++ b/server/src/main/java/com/ryc/api/v2/announcement/infra/AnnouncementRepositoryImpl.java
@@ -1,8 +1,7 @@
 package com.ryc.api.v2.announcement.infra;
 
 import java.util.List;
-
-import jakarta.persistence.EntityNotFoundException;
+import java.util.NoSuchElementException;
 
 import org.springframework.stereotype.Repository;
 
@@ -41,7 +40,7 @@ public class AnnouncementRepositoryImpl implements AnnouncementRepository {
     AnnouncementEntity announcementEntity =
         announcementJpaRepository
             .findById(id)
-            .orElseThrow(() -> new EntityNotFoundException("announcement not found"));
+            .orElseThrow(() -> new NoSuchElementException("announcement not found"));
 
     return AnnouncementMapper.toDomain(announcementEntity);
   }
@@ -61,7 +60,7 @@ public class AnnouncementRepositoryImpl implements AnnouncementRepository {
       AnnouncementEntity announcementEntity =
           announcementJpaRepository
               .findById(announcement.getId())
-              .orElseThrow(() -> new EntityNotFoundException("announcement not found"));
+              .orElseThrow(() -> new NoSuchElementException("announcement not found"));
 
       AnnouncementEntity updatedInfoEntity = AnnouncementMapper.toEntity(announcement);
       announcementEntity.update(updatedInfoEntity);

--- a/server/src/main/java/com/ryc/api/v2/applicant/infra/ApplicantRepositoryImpl.java
+++ b/server/src/main/java/com/ryc/api/v2/applicant/infra/ApplicantRepositoryImpl.java
@@ -1,9 +1,8 @@
 package com.ryc.api.v2.applicant.infra;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
-
-import jakarta.persistence.EntityNotFoundException;
 
 import org.springframework.stereotype.Repository;
 
@@ -30,7 +29,7 @@ public class ApplicantRepositoryImpl implements ApplicantRepository {
   public String findEmailById(String id) {
     return applicantJpaRepository
         .findEmailById(id)
-        .orElseThrow(() -> new EntityNotFoundException("Applicant not found with id: " + id));
+        .orElseThrow(() -> new NoSuchElementException("Applicant not found with id: " + id));
   }
 
   @Override
@@ -38,7 +37,7 @@ public class ApplicantRepositoryImpl implements ApplicantRepository {
     return applicantJpaRepository
         .findById(id)
         .map(ApplicantMapper::toDomain)
-        .orElseThrow(() -> new EntityNotFoundException("Applicant not found"));
+        .orElseThrow(() -> new NoSuchElementException("Applicant not found with id: " + id));
   }
 
   @Override

--- a/server/src/main/java/com/ryc/api/v2/application/infra/ApplicationRepositoryImpl.java
+++ b/server/src/main/java/com/ryc/api/v2/application/infra/ApplicationRepositoryImpl.java
@@ -3,9 +3,8 @@ package com.ryc.api.v2.application.infra;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
-
-import jakarta.persistence.EntityNotFoundException;
 
 import org.springframework.stereotype.Repository;
 
@@ -45,7 +44,7 @@ public class ApplicationRepositoryImpl implements ApplicationRepository {
     return applicationJpaRepository
         .findByApplicantId(applicantId)
         .map(ApplicationMapper::toDomain)
-        .orElseThrow(() -> new EntityNotFoundException("Application not found"));
+        .orElseThrow(() -> new NoSuchElementException("Application not found"));
   }
 
   @Override

--- a/server/src/main/java/com/ryc/api/v2/applicationForm/infra/ApplicationFormRepositoryImpl.java
+++ b/server/src/main/java/com/ryc/api/v2/applicationForm/infra/ApplicationFormRepositoryImpl.java
@@ -1,6 +1,6 @@
 package com.ryc.api.v2.applicationForm.infra;
 
-import jakarta.persistence.EntityNotFoundException;
+import java.util.NoSuchElementException;
 
 import org.springframework.stereotype.Repository;
 
@@ -22,7 +22,7 @@ public class ApplicationFormRepositoryImpl implements ApplicationFormRepository 
     ApplicationFormEntity applicationFormEntity =
         applicationFormJpaRepository
             .findByAnnouncementId(id)
-            .orElseThrow(() -> new EntityNotFoundException("announcementApplication not found"));
+            .orElseThrow(() -> new NoSuchElementException("announcementApplication not found"));
 
     return ApplicationFormMapper.toDomain(applicationFormEntity);
   }

--- a/server/src/main/java/com/ryc/api/v2/auth/service/AuthService.java
+++ b/server/src/main/java/com/ryc/api/v2/auth/service/AuthService.java
@@ -2,8 +2,7 @@ package com.ryc.api.v2.auth.service;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-
-import jakarta.persistence.EntityNotFoundException;
+import java.util.NoSuchElementException;
 
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -66,7 +65,7 @@ public class AuthService {
     Admin admin =
         refreshTokenRepository
             .findAdminByToken(refreshToken)
-            .orElseThrow(() -> new EntityNotFoundException("Refresh token not found."));
+            .orElseThrow(() -> new NoSuchElementException("Refresh token not found."));
 
     // 3. 신규 at 생성
     final String accessToken =
@@ -74,7 +73,7 @@ public class AuthService {
 
     // 4. 기존 rt db삭제
     if (!refreshTokenRepository.deleteRefreshTokenByToken(refreshToken)) {
-      throw new EntityNotFoundException("RefreshToken not found");
+      throw new NoSuchElementException("RefreshToken not found");
     }
 
     // TODO: 추후 update 방식으로 수정하는 것이 안전할 것으로 보임.
@@ -107,7 +106,7 @@ public class AuthService {
     Admin admin =
         adminRepository
             .findById(adminId)
-            .orElseThrow(() -> new EntityNotFoundException("Admin not found with id: " + adminId));
+            .orElseThrow(() -> new NoSuchElementException("Admin not found with id: " + adminId));
 
     refreshTokenRepository.deleteRefreshTokenByAdmin(admin);
     refreshTokenRepository.flush();
@@ -122,7 +121,7 @@ public class AuthService {
     boolean deleted = refreshTokenRepository.deleteRefreshTokenByToken(refreshToken);
     // TODO: 삭제 실패인지, 해당 토큰이 DB에 없는 것인지 구분 필요.
     if (!deleted) {
-      throw new EntityNotFoundException("RefreshToken not found for logout.");
+      throw new NoSuchElementException("RefreshToken not found for logout.");
     }
   }
 }

--- a/server/src/main/java/com/ryc/api/v2/club/infra/ClubRepositoryImpl.java
+++ b/server/src/main/java/com/ryc/api/v2/club/infra/ClubRepositoryImpl.java
@@ -1,8 +1,7 @@
 package com.ryc.api.v2.club.infra;
 
 import java.util.List;
-
-import jakarta.persistence.EntityNotFoundException;
+import java.util.NoSuchElementException;
 
 import org.springframework.stereotype.Repository;
 
@@ -33,7 +32,7 @@ public class ClubRepositoryImpl implements ClubRepository {
     ClubEntity entity =
         clubJpaRepository
             .findById(id)
-            .orElseThrow(() -> new EntityNotFoundException("동아리를 찾을 수 없습니다."));
+            .orElseThrow(() -> new NoSuchElementException("동아리를 찾을 수 없습니다."));
     return ClubMapper.toDomain(entity);
   }
 

--- a/server/src/main/java/com/ryc/api/v2/common/aop/aspect/ClubAspect.java
+++ b/server/src/main/java/com/ryc/api/v2/common/aop/aspect/ClubAspect.java
@@ -1,6 +1,6 @@
 package com.ryc.api.v2.common.aop.aspect;
 
-import jakarta.persistence.EntityNotFoundException;
+import java.util.NoSuchElementException;
 
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
@@ -25,7 +25,7 @@ public class ClubAspect {
     String clubId = extractParameters(signature.getParameterNames(), joinPoint.getArgs());
 
     if (!clubService.existClubById(clubId)) {
-      throw new EntityNotFoundException("동아리를 찾을 수 없습니다.");
+      throw new NoSuchElementException("동아리를 찾을 수 없습니다.");
     }
   }
 

--- a/server/src/main/java/com/ryc/api/v2/common/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/ryc/api/v2/common/exception/GlobalExceptionHandler.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
-import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.ConstraintViolationException;
 
 import org.springframework.dao.DataIntegrityViolationException;
@@ -81,12 +80,6 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
   @ExceptionHandler(ConstraintViolationException.class)
   public ResponseEntity<Object> handleConstraintViolationException(ConstraintViolationException e) {
     ErrorCode errorCode = CommonErrorCode.INVALID_PARAMETER;
-    return handleExceptionInternal(errorCode, e.getMessage());
-  }
-
-  @ExceptionHandler(EntityNotFoundException.class)
-  public ResponseEntity<Object> handleEntityNotFoundException(EntityNotFoundException e) {
-    ErrorCode errorCode = CommonErrorCode.RESOURCE_NOT_FOUND;
     return handleExceptionInternal(errorCode, e.getMessage());
   }
 

--- a/server/src/main/java/com/ryc/api/v2/evaluation/infra/EvaluationRepositoryImpl.java
+++ b/server/src/main/java/com/ryc/api/v2/evaluation/infra/EvaluationRepositoryImpl.java
@@ -1,8 +1,7 @@
 package com.ryc.api.v2.evaluation.infra;
 
 import java.util.List;
-
-import jakarta.persistence.EntityNotFoundException;
+import java.util.NoSuchElementException;
 
 import org.springframework.stereotype.Repository;
 
@@ -37,14 +36,14 @@ public class EvaluationRepositoryImpl implements EvaluationRepository {
         adminJpaRepository
             .findById(evaluation.getEvaluatorId())
             .filter(entity -> !entity.getDeleted())
-            .orElseThrow(() -> new EntityNotFoundException("AdminEntity not found or deleted"));
+            .orElseThrow(() -> new NoSuchElementException("AdminEntity not found or deleted"));
 
     ApplicantEntity applicantEntity =
         applicantJpaRepository
             .findById(evaluation.getEvaluateeId())
             // TODO: applicant 논리 삭제 허용시, 아래 필터 추가
             //                        .filter(entity -> !entity.getDeleted())
-            .orElseThrow(() -> new EntityNotFoundException("ApplicantEntity not found or deleted"));
+            .orElseThrow(() -> new NoSuchElementException("ApplicantEntity not found or deleted"));
 
     EvaluationEntity evaluationEntity =
         EvaluationMapper.toEntity(evaluation, adminEntity, applicantEntity);
@@ -77,7 +76,7 @@ public class EvaluationRepositoryImpl implements EvaluationRepository {
         .findById(evaluationId)
         .filter(e -> !e.getDeleted())
         .map(EvaluationMapper::toDomain)
-        .orElseThrow(() -> new EntityNotFoundException("evaluationEntity not found or deleted"));
+        .orElseThrow(() -> new NoSuchElementException("evaluationEntity not found or deleted"));
   }
 
   @Override

--- a/server/src/main/java/com/ryc/api/v2/file/infra/FileMetaDataRepositoryImpl.java
+++ b/server/src/main/java/com/ryc/api/v2/file/infra/FileMetaDataRepositoryImpl.java
@@ -2,10 +2,9 @@ package com.ryc.api.v2.file.infra;
 
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
-import jakarta.persistence.EntityNotFoundException;
 
 import org.springframework.stereotype.Repository;
 
@@ -33,7 +32,7 @@ public class FileMetaDataRepositoryImpl implements FileMetaDataRepository {
       FileMetadataEntity fileMetadataEntity =
           fileMetadataJpaRepository
               .findById(fileMetaData.getId())
-              .orElseThrow(() -> new EntityNotFoundException("fileMetaData not found"));
+              .orElseThrow(() -> new NoSuchElementException("fileMetaData not found"));
 
       fileMetadataEntity.update(FileMetaDataMapper.toEntity(fileMetaData));
       return FileMetaDataMapper.toDomain(fileMetadataEntity);
@@ -46,7 +45,7 @@ public class FileMetaDataRepositoryImpl implements FileMetaDataRepository {
         fileMetadataJpaRepository
             .findById(id)
             .filter(entity -> !entity.isDeleted())
-            .orElseThrow(() -> new EntityNotFoundException("fileMetaData not found")));
+            .orElseThrow(() -> new NoSuchElementException("fileMetaData not found")));
   }
 
   @Override
@@ -79,7 +78,7 @@ public class FileMetaDataRepositoryImpl implements FileMetaDataRepository {
 
     // 3. 둘이 개수 안맞으면 잘못된 요청
     if (fileMetaDataList.size() != fileMetadataMap.size()) {
-      throw new EntityNotFoundException("fileMetaData not found");
+      throw new NoSuchElementException("fileMetaData not found");
     }
 
     // 4. update

--- a/server/src/main/java/com/ryc/api/v2/interview/domain/InterviewSlot.java
+++ b/server/src/main/java/com/ryc/api/v2/interview/domain/InterviewSlot.java
@@ -4,8 +4,7 @@ import static com.ryc.api.v2.common.constant.DomainDefaultValues.DEFAULT_INITIAL
 
 import java.util.ArrayList;
 import java.util.List;
-
-import jakarta.persistence.EntityNotFoundException;
+import java.util.NoSuchElementException;
 
 import com.ryc.api.v2.announcement.domain.vo.Period;
 import com.ryc.api.v2.announcement.presentation.dto.request.PeriodRequest;
@@ -54,10 +53,10 @@ public class InterviewSlot {
     if (maxNumberOfPeople == interviewReservations.size()) {
       if (allowOverMax) {
         maxCount++;
+      } else {
+        // 예약이 꽉 찼고, 추가 예약을 허용하지 않는 경우 예외 발생
+        throw new InterviewException(InterviewErrorCode.INTERVIEW_SLOT_FULL);
       }
-
-      // 예약이 꽉 찼고, 추가 예약을 허용하지 않는 경우 예외 발생
-      throw new InterviewException(InterviewErrorCode.INTERVIEW_SLOT_FULL);
     }
 
     newInterviewReservations.add(newReservation);
@@ -91,7 +90,7 @@ public class InterviewSlot {
     return this.interviewReservations.stream()
         .filter(reservation -> reservation.getId().equals(reservationId))
         .findFirst()
-        .orElseThrow(() -> new EntityNotFoundException("Interview slot not found"));
+        .orElseThrow(() -> new NoSuchElementException("Interview slot not found"));
   }
 
   // Getter 어노테이션이 생성하는 Get 메서드보다 직접 작성한 Get 메서드가 우선시 됨.

--- a/server/src/main/java/com/ryc/api/v2/interview/infra/InterviewRepositoryImpl.java
+++ b/server/src/main/java/com/ryc/api/v2/interview/infra/InterviewRepositoryImpl.java
@@ -1,8 +1,7 @@
 package com.ryc.api.v2.interview.infra;
 
 import java.util.List;
-
-import jakarta.persistence.EntityNotFoundException;
+import java.util.NoSuchElementException;
 
 import org.springframework.stereotype.Repository;
 
@@ -49,7 +48,7 @@ public class InterviewRepositoryImpl implements InterviewRepository {
     InterviewSlotEntity entity =
         interviewSlotJpaRepository
             .findByIdForUpdate(interviewSlotId)
-            .orElseThrow(() -> new EntityNotFoundException("Interview slot not found"));
+            .orElseThrow(() -> new NoSuchElementException("Interview slot not found"));
     return InterviewSlotMapper.toDomain(entity);
   }
 
@@ -60,7 +59,7 @@ public class InterviewRepositoryImpl implements InterviewRepository {
             .findInterviewSlotById(interviewReservationId)
             .orElseThrow(
                 () ->
-                    new EntityNotFoundException(
+                    new NoSuchElementException(
                         "Interview slot not found for reservation ID: " + interviewReservationId));
     return InterviewSlotMapper.toDomain(entity);
   }


### PR DESCRIPTION
## 📌 관련 이슈
close #333 

## 🛠️ 작업 내용
- [x] EntityNotFoundException -> NoSuchElementException 변경

## 🎯 리뷰 포인트
기존에 `RepositoryImpl`에서 `EntityNotFoundException`을 throw 하였을 때, 
Controller까지 오는 과정에 `JpaObjectRetrievalFailureException`로 번역되어 오는 과정이 존재하였습니다.
따라서 기존의 문제점은 `GlobalExceptionHandler`에서 해당 Exception을 잡지 못하여, `500 server error`를 받는 오류가 있었습니다.

이 문제를 `NoSuchElementException`을 활용하여 `404 NOT FOUND`를 반환하도록 수정하였습니다.

따라서 추가로 조회 API를 개발할 때 `EntityNotFound`가 아닌, `NoSuchElement` 예외를 throw하도록 참고해 주시면 감사하겠습니다.