### PR TITLE
[BE/HOTFIX] EntityNotFoundException, NoSuchElementException으로 대체

### DIFF
--- a/server/src/main/java/com/ryc/api/v2/announcement/infra/AnnouncementRepositoryImpl.java
+++ b/server/src/main/java/com/ryc/api/v2/announcement/infra/AnnouncementRepositoryImpl.java
@@ -103,7 +103,7 @@ public class AnnouncementRepositoryImpl implements AnnouncementRepository {
     return announcementJpaRepository
         .findById(announcementId)
         .filter(announcementEntity -> !announcementEntity.getIsDeleted())
-        .orElseThrow(() -> new EntityNotFoundException("announcement not found"))
+        .orElseThrow(() -> new NoSuchElementException("announcement not found"))
         .getApplicationForm()
         .getPersonalInfoQuestions()
         .contains(PersonalInfoQuestionType.PROFILE_IMAGE);


### PR DESCRIPTION
## 🛠️ HOTFIX
develop 브랜치에 반영된, EntityNotFoundException 사용 제한을 확인하지 못하여, NoSuchElementException으로 대체하여 다시 PR 남깁니다. 
EntityNotFoundException을 사용한 경우, 빌드시에서 제한되는데 해당 내용 공유 부탁드립니다!