### PR TITLE
[BE] Applicant, Application 조회 시 File 조회 로직 변경

### DIFF
--- a/server/src/main/java/com/ryc/api/v2/applicant/infra/entity/ApplicantPersonalInfoEntity.java
+++ b/server/src/main/java/com/ryc/api/v2/applicant/infra/entity/ApplicantPersonalInfoEntity.java
@@ -23,6 +23,7 @@ public class ApplicantPersonalInfoEntity {
   private String value;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "applicant_id")
+  @JoinColumn(name = "applicant_id", nullable = false)
+  @Setter
   private ApplicantEntity applicant;
 }

--- a/server/src/main/java/com/ryc/api/v2/applicant/infra/mapper/ApplicantMapper.java
+++ b/server/src/main/java/com/ryc/api/v2/applicant/infra/mapper/ApplicantMapper.java
@@ -35,14 +35,21 @@ public class ApplicantMapper {
             .map(ApplicantPersonalInfoMapper::toEntity)
             .collect(Collectors.toCollection(ArrayList::new));
 
-    return ApplicantEntity.builder()
-        .id(domain.getId())
-        .announcementId(domain.getAnnouncementId())
-        .status(domain.getStatus())
-        .isDeleted(domain.getIsDeleted())
-        .email(domain.getEmail())
-        .name(domain.getName())
-        .personalInfos(personalInfos)
-        .build();
+    ApplicantEntity applicantEntity =
+        ApplicantEntity.builder()
+            .id(domain.getId())
+            .announcementId(domain.getAnnouncementId())
+            .status(domain.getStatus())
+            .isDeleted(domain.getIsDeleted())
+            .email(domain.getEmail())
+            .name(domain.getName())
+            .personalInfos(personalInfos)
+            .build();
+
+      for (ApplicantPersonalInfoEntity infoEntity : personalInfos) {
+          infoEntity.setApplicant(applicantEntity);
+      }
+
+      return applicantEntity;
   }
 }

--- a/server/src/main/java/com/ryc/api/v2/applicant/presentation/dto/response/ApplicantGetResponse.java
+++ b/server/src/main/java/com/ryc/api/v2/applicant/presentation/dto/response/ApplicantGetResponse.java
@@ -3,6 +3,7 @@ package com.ryc.api.v2.applicant.presentation.dto.response;
 import java.time.LocalDateTime;
 
 import com.ryc.api.v2.applicant.domain.enums.ApplicantStatus;
+import com.ryc.api.v2.common.dto.response.FileGetResponse;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -13,4 +14,5 @@ public record ApplicantGetResponse(
     @Schema(description = "지원자 이름", example = "홍길동") String name,
     @Schema(description = "지원자 이메일", example = "gildong@example.com") String email,
     @Schema(description = "지원 상태", example = "DOCUMENT_PENDING") ApplicantStatus status,
-    @Schema(description = "제출 일시", example = "2025-07-22T10:00:00") LocalDateTime submittedAt) {}
+    @Schema(description = "제출 일시", example = "2025-07-22T10:00:00") LocalDateTime submittedAt,
+    @Schema(description = "프로필 이미지 파일 정보") FileGetResponse profileImage) {}

--- a/server/src/main/java/com/ryc/api/v2/application/presentation/dto/response/AnswerResponse.java
+++ b/server/src/main/java/com/ryc/api/v2/application/presentation/dto/response/AnswerResponse.java
@@ -1,11 +1,13 @@
 package com.ryc.api.v2.application.presentation.dto.response;
 
 import java.util.List;
+import java.util.Map;
 
 import com.ryc.api.v2.application.domain.Answer;
 import com.ryc.api.v2.application.domain.AnswerChoice;
 import com.ryc.api.v2.applicationForm.domain.Question;
 import com.ryc.api.v2.applicationForm.domain.enums.QuestionType;
+import com.ryc.api.v2.common.dto.response.FileGetResponse;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -23,9 +25,7 @@ public record AnswerResponse(
     // 응답값
     @Schema(description = "서술형 답변", example = "안녕하세요...") String textAnswer,
     @Schema(description = "선택형 답변") List<String> selectedOptionIds,
-    @Schema(description = "첨부 파일 URL", example = "https://.../file.pdf")
-        String fileUrl // TODO: S3 연동 후 실제 URL 매핑 필요
-    ) {
+    @Schema(description = "첨부 파일 정보") FileGetResponse file) {
   public static AnswerResponse of(Answer answer, Question question) {
     List<QuestionOptionResponse> questionOptions =
         question.getOptions().stream().map(QuestionOptionResponse::from).toList();
@@ -41,7 +41,32 @@ public record AnswerResponse(
         .questionType(question.getQuestionType())
         .textAnswer(answer.getTextAnswer())
         .selectedOptionIds(selectedOptionIds)
-        .fileUrl(null) // TODO: S3 연동
+        .file(null)
+        .build();
+  }
+
+  public static AnswerResponse of(
+      Answer answer, Question question, Map<String, FileGetResponse> fileMap) {
+    List<QuestionOptionResponse> questionOptions =
+        question.getOptions().stream().map(QuestionOptionResponse::from).toList();
+
+    List<String> selectedOptionIds =
+        answer.getChoices().stream().map(AnswerChoice::getOptionId).toList();
+
+    FileGetResponse file = null;
+    if (fileMap != null && answer.getFileMetadataId() != null) {
+      file = fileMap.get(answer.getFileMetadataId());
+    }
+
+    return AnswerResponse.builder()
+        .questionId(answer.getQuestionId())
+        .questionLabel(question.getLabel())
+        .isRequired(question.isRequired())
+        .questionOptions(questionOptions)
+        .questionType(question.getQuestionType())
+        .textAnswer(answer.getTextAnswer())
+        .selectedOptionIds(selectedOptionIds)
+        .file(file)
         .build();
   }
 }

--- a/server/src/main/java/com/ryc/api/v2/application/presentation/dto/response/ApplicationGetResponse.java
+++ b/server/src/main/java/com/ryc/api/v2/application/presentation/dto/response/ApplicationGetResponse.java
@@ -7,10 +7,13 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import com.ryc.api.v2.applicant.domain.Applicant;
+import com.ryc.api.v2.applicant.domain.ApplicantPersonalInfo;
 import com.ryc.api.v2.applicant.domain.enums.ApplicantStatus;
 import com.ryc.api.v2.application.domain.Application;
 import com.ryc.api.v2.applicationForm.domain.ApplicationForm;
 import com.ryc.api.v2.applicationForm.domain.Question;
+import com.ryc.api.v2.applicationForm.domain.enums.PersonalInfoQuestionType;
+import com.ryc.api.v2.common.dto.response.FileGetResponse;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -23,15 +26,28 @@ public record ApplicationGetResponse(
     @Schema(description = "지원자 이메일", example = "gildong@example.com") String email,
     @Schema(description = "지원 상태", example = "DOCUMENT_PENDING") ApplicantStatus status,
     @Schema(description = "제출 일시", example = "2025-07-22T10:00:00") LocalDateTime submittedAt,
+    @Schema(description = "프로필 이미지 파일 정보") FileGetResponse profileImage,
     @Schema(description = "추가 개인정보 목록") List<ApplicantPersonalInfoResponse> personalInfos,
     @Schema(description = "사전 질문 답변 목록") List<AnswerResponse> preQuestionAnswers,
     @Schema(description = "본 질문 답변 목록") List<AnswerResponse> applicationQuestionAnswers) {
   public static ApplicationGetResponse of(
-      Applicant applicant, Application application, ApplicationForm applicationForm) {
+      Applicant applicant,
+      Application application,
+      ApplicationForm applicationForm,
+      Map<String, FileGetResponse> fileMap) {
     List<ApplicantPersonalInfoResponse> personalInfoResponses =
         applicant.getPersonalInfos().stream()
             .map(ApplicantPersonalInfoResponse::from)
             .collect(Collectors.toList());
+
+    String profileFileId =
+        applicant.getPersonalInfos().stream()
+            .filter(pi -> pi.getQuestionType() == PersonalInfoQuestionType.PROFILE_IMAGE)
+            .map(ApplicantPersonalInfo::getValue)
+            .filter(v -> v != null && !v.isBlank())
+            .findFirst()
+            .orElse(null);
+    FileGetResponse profileFile = profileFileId == null ? null : fileMap.get(profileFileId);
 
     Map<String, Question> preQuestionMap =
         applicationForm.getPreQuestions().stream()
@@ -44,7 +60,9 @@ public record ApplicationGetResponse(
     List<AnswerResponse> preQuestionAnswers =
         application.getAnswers().stream()
             .filter(answer -> preQuestionMap.containsKey(answer.getQuestionId()))
-            .map(answer -> AnswerResponse.of(answer, preQuestionMap.get(answer.getQuestionId())))
+            .map(
+                answer ->
+                    AnswerResponse.of(answer, preQuestionMap.get(answer.getQuestionId()), fileMap))
             .toList();
 
     List<AnswerResponse> applicationQuestionAnswers =
@@ -52,7 +70,8 @@ public record ApplicationGetResponse(
             .filter(answer -> applicationQuestionMap.containsKey(answer.getQuestionId()))
             .map(
                 answer ->
-                    AnswerResponse.of(answer, applicationQuestionMap.get(answer.getQuestionId())))
+                    AnswerResponse.of(
+                        answer, applicationQuestionMap.get(answer.getQuestionId()), fileMap))
             .toList();
 
     return ApplicationGetResponse.builder()
@@ -60,7 +79,8 @@ public record ApplicationGetResponse(
         .name(applicant.getName())
         .email(applicant.getEmail())
         .status(applicant.getStatus())
-        .submittedAt(application.getCreatedAt()) // Assuming Application has createdAt
+        .submittedAt(application.getCreatedAt())
+        .profileImage(profileFile)
         .personalInfos(personalInfoResponses)
         .preQuestionAnswers(preQuestionAnswers)
         .applicationQuestionAnswers(applicationQuestionAnswers)

--- a/server/src/main/java/com/ryc/api/v2/file/domain/FileMetaData.java
+++ b/server/src/main/java/com/ryc/api/v2/file/domain/FileMetaData.java
@@ -112,19 +112,35 @@ public class FileMetaData {
         .build();
   }
 
-  public FileMetaData issueFileMoveSuccess(String filePath) {
+  public FileMetaData issueFileMoveSuccess(String finalS3Key) {
     return FileMetaData.builder()
-        .id(id)
-        .filePath(filePath)
-        .originalFileName(originalFileName)
-        .contentType(contentType)
-        .fileSize(fileSize)
-        .fileDomainType(fileDomainType)
-        .associatedId(associatedId)
-        .uploadedByUserId(uploadedByUserId)
+        .id(this.id)
+        .filePath(finalS3Key)
+        .originalFileName(this.originalFileName)
+        .contentType(this.contentType)
+        .fileSize(this.fileSize)
+        .fileDomainType(this.fileDomainType)
+        .uploadedByUserId(this.uploadedByUserId)
+        .associatedId(this.associatedId)
+        .displayOrder(this.displayOrder)
+        .isDeleted(false)
         .status(FileStatus.ATTACHED)
-        .isDeleted(isDeleted)
-        .displayOrder(displayOrder)
+        .build();
+  }
+
+  public FileMetaData issueFileMoveFail() {
+    return FileMetaData.builder()
+        .id(this.id)
+        .filePath(this.filePath)
+        .originalFileName(this.originalFileName)
+        .contentType(this.contentType)
+        .fileSize(this.fileSize)
+        .fileDomainType(this.fileDomainType)
+        .uploadedByUserId(this.uploadedByUserId)
+        .associatedId(this.associatedId)
+        .isDeleted(false)
+        .displayOrder(this.displayOrder)
+        .status(FileStatus.MOVE_FAILED)
         .build();
   }
 
@@ -137,24 +153,9 @@ public class FileMetaData {
         .fileSize(fileSize)
         .fileDomainType(fileDomainType)
         .associatedId(associatedId)
+        .isDeleted(false)
         .uploadedByUserId(uploadedByUserId)
         .status(status)
-        .isDeleted(isDeleted)
-        .displayOrder(displayOrder)
-        .build();
-  }
-
-  public FileMetaData issueFileMoveFail() {
-    return FileMetaData.builder()
-        .id(id)
-        .filePath(filePath)
-        .originalFileName(originalFileName)
-        .contentType(contentType)
-        .fileSize(fileSize)
-        .fileDomainType(fileDomainType)
-        .associatedId(associatedId)
-        .uploadedByUserId(uploadedByUserId)
-        .status(FileStatus.MOVE_FAILED)
         .isDeleted(isDeleted)
         .displayOrder(displayOrder)
         .build();


### PR DESCRIPTION
## 📌 관련 이슈
#338 

## 🛠️ 작업 내용
PR에서 작업한 주요 내용을 적어주세요.
- [ ] ApplicantPersonalInfo 객체 오류 수정
- [ ] Applicant도메인 적용
- [ ] Application도메인 적용

## 🎯 리뷰 포인트
Applicant와 Application 도메인의 File의 Get권한은 해당 클럽의 멤버들만 가지게 됩니다.
지원자는 현재는 지원서 제출후 수정 기능이 존재하지 않기 떄문에 제외 해두었습니다.
또한 해당 File의 Get링크는 presigned-url로 제공하기 때문에 현재 설정된 시간(10분)동안만 접근 가능합니다.

- 리뷰 포인트

## ⏳ 작업 시간
추정 시간:   1일
실제 시간:   1일
이유: 차이가 많이 난다면 이유도 같이 적어주세요 :)
