### PR TITLE
[FE] 유저 메인페이지, 관리자 페이지 수정

### DIFF
--- a/monorepo/apps/admin/src/pages/EntryPage/EntryPage.style.ts
+++ b/monorepo/apps/admin/src/pages/EntryPage/EntryPage.style.ts
@@ -1,4 +1,4 @@
-import backgroundImage from '@assets/images/background.png';
+import backgroundImage from '@assets/images/background.webp';
 import { css, keyframes } from '@emotion/react';
 
 import theme from '@ssoc/styles';

--- a/monorepo/apps/admin/src/types/images.d.ts
+++ b/monorepo/apps/admin/src/types/images.d.ts
@@ -2,3 +2,4 @@ declare module '*.png';
 declare module '*.jpg';
 declare module '*.jpeg';
 declare module '*.svg';
+declare module '*.webp';

--- a/monorepo/apps/admin/webpack.common.js
+++ b/monorepo/apps/admin/webpack.common.js
@@ -23,7 +23,7 @@ module.exports = {
                 use: ['@svgr/webpack'],
             },
             {
-                test: /\.(png|jpe?g|gif)$/,
+                test: /\.(png|jpe?g|gif|webp)$/,
                 type: 'asset/resource',
             },
             {

--- a/monorepo/apps/user/src/components/ClubBox/ClubBox.style.ts
+++ b/monorepo/apps/user/src/components/ClubBox/ClubBox.style.ts
@@ -9,9 +9,12 @@ export const clubBoxContainer = css`
     column-gap: 10rem;
     row-gap: 2rem;
     background-color: ${theme.colors.gray[100]};
-    padding: 2rem 3rem;
+    padding: 2rem 2rem;
     border-radius: 15px;
 
+    @media (min-width: ${theme.breakpoint.mobile}) {
+        padding: 2rem 3rem;
+    }
     @media (min-width: ${theme.breakpoint.tabletMini}) {
         grid-template-columns: repeat(2, 1fr);
     }

--- a/monorepo/apps/user/src/components/ClubBox/ClubBox.tsx
+++ b/monorepo/apps/user/src/components/ClubBox/ClubBox.tsx
@@ -29,7 +29,7 @@ function ClubBox({ data }: ClubBoxProps) {
                     >
                         {data.title}
                     </Text>
-                    <Text as="div" type="bodyRegular" textAlign="start" noWrap>
+                    <Text as="div" type="bodyRegular" textAlign="start" noWrap cropped>
                         {data.value}
                     </Text>
                 </div>

--- a/monorepo/apps/user/src/components/Header/Header.tsx
+++ b/monorepo/apps/user/src/components/Header/Header.tsx
@@ -12,24 +12,11 @@ function Header() {
         <header css={headerBarContainer}>
             <div css={homeNavContainer}>
                 <Link to="/">
-                    <Text as="h1" type="h4Light" color="caption">
-                        <Text.HighLight sx={{ color: 'black', fontWeight: 'bold' }}>
-                            R
-                        </Text.HighLight>
-                        ecruiting
-                    </Text>
-                    <Text as="h1" type="h4Light" color="caption" textAlign="start">
-                        <Text.HighLight sx={{ color: 'black', fontWeight: 'bold' }}>
-                            Y
-                        </Text.HighLight>
-                        our
-                        <Text.HighLight sx={{ color: 'black', fontWeight: 'bold' }}>
-                            C
-                        </Text.HighLight>
-                        lub
+                    <Text as="h1" type="h1Bold" color="black">
+                        SSOC
                     </Text>
                 </Link>
-                <nav css={navContainer}>
+                {/* <nav css={navContainer}>
                     <Input
                         variant="transparent"
                         startNode={
@@ -46,7 +33,7 @@ function Header() {
                         }}
                         placeholder="동아리명 검색 또는 키워드 입력"
                     />
-                </nav>
+                </nav> */}
             </div>
         </header>
     );

--- a/monorepo/apps/user/src/components/RecruitCard/RecruitCard.style.tsx
+++ b/monorepo/apps/user/src/components/RecruitCard/RecruitCard.style.tsx
@@ -26,6 +26,7 @@ export const recruitCardHeader = css`
     display: flex;
     justify-content: space-between;
     align-items: center;
+    width: 100%;
     padding: 1rem;
     gap: 1rem;
 `;
@@ -41,6 +42,7 @@ export const recruitCardBody = css`
     display: flex;
     flex-wrap: wrap;
     flex: 1;
+    width: 100%;
     padding: 1rem;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -50,5 +52,6 @@ export const recruitCardFooter = css`
     display: flex;
     width: 23rem;
     padding: 1rem;
+    width: 100%;
     gap: 0.5rem;
 `;

--- a/monorepo/apps/user/src/components/RecruitCard/RecruitCard.tsx
+++ b/monorepo/apps/user/src/components/RecruitCard/RecruitCard.tsx
@@ -33,7 +33,7 @@ function RecruitCard(props: RecruitCardProps) {
                     <Text noWrap cropped>
                         {title}
                     </Text>
-                    <Text color="caption" sx={deadlineText(diffDay)} noWrap>
+                    <Text color="caption" sx={deadlineText(diffDay)} noWrap cropped>
                         {displayText}
                     </Text>
                 </div>

--- a/monorepo/apps/user/src/index.tsx
+++ b/monorepo/apps/user/src/index.tsx
@@ -17,7 +17,7 @@ const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 const queryClient = new QueryClient();
 dayjs.locale('ko'); // dayjs를 한국기준으로 설정
 
-const Channeltalk = () => {
+const Channeltalk = async () => {
     ChannelService.loadScript();
     ChannelService.boot({
         pluginKey: `${process.env.CHANNEL_PLUGIN_KEY}`,
@@ -32,7 +32,7 @@ async function initializeApp() {
     if (process.env.API_MOCKING === 'enabled') {
         await browserServer.start();
     }
-    Channeltalk();
+    await Channeltalk();
     root.render(
         <React.StrictMode>
             <Global styles={globalStyles} />

--- a/monorepo/apps/user/src/pages/MainPage/MainPage.style.ts
+++ b/monorepo/apps/user/src/pages/MainPage/MainPage.style.ts
@@ -41,7 +41,11 @@ export const totalClubContainer = css`
     flex-direction: column;
     align-items: start;
     padding: 0rem 0.5rem;
+    padding-left: 1rem;
     gap: 0.5rem;
+    @media (min-width: ${theme.breakpoint.mobile}) {
+        padding-left: 0.5rem;
+    }
 `;
 
 export const clubCategoryContainer = css`
@@ -52,6 +56,29 @@ export const clubCategoryContainer = css`
     height: 3.5rem;
 `;
 
+export const categoryProgressContainer = css`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex: 1;
+    width: 100%;
+    padding-right: 1rem;
+    @media (min-width: ${theme.breakpoint.mobile}) {
+        justify-content: end;
+    }
+`;
+export const categoryDropdown = css`
+    @media (min-width: ${theme.breakpoint.mobile}) {
+        display: none;
+    }
+`;
+export const dropdownItem = css`
+    display: flex;
+    flex-direction: column;
+    height: 20rem;
+    overflow-y: auto;
+    gap: 0.5rem;
+`;
 export const divider = css`
     width: 100%;
     background-color: ${theme.colors.gray[200]};

--- a/monorepo/apps/user/src/pages/MainPage/MainPage.tsx
+++ b/monorepo/apps/user/src/pages/MainPage/MainPage.tsx
@@ -6,15 +6,18 @@ import React, { useMemo, useState } from 'react';
 
 import banner from '@ssoc/assets/images/banner.png';
 import Check from '@ssoc/assets/images/check.svg';
-import { Button, Text } from '@ssoc/ui';
+import { Button, Dropdown, Text } from '@ssoc/ui';
 
 import {
     bannerContainer,
     categoryButton,
+    categoryDropdown,
+    categoryProgressContainer,
     categorySlider,
     clubCategoryContainer,
     clubListContainer,
     divider,
+    dropdownItem,
     emptyElement,
     mainPageContainer,
     progressContainer,
@@ -75,7 +78,7 @@ function MainPage() {
                 <img src={banner} alt="배너 이미지" width="100%" height="100%" />
             </div>
             <div css={totalClubContainer}>
-                <Text type="h4Semibold" color="black">
+                <Text type="bodySemibold" color="black">
                     총 {filteredClubData?.length}개의 동아리
                 </Text>
             </div>
@@ -92,16 +95,39 @@ function MainPage() {
                         {category.name}
                     </Button>
                 ))}
-                <div css={emptyElement} />
-                <Button
-                    variant="text"
-                    size="md"
-                    sx={progressContainer(isProgress)}
-                    onClick={() => setIsProgress((prev) => !prev)}
-                >
-                    <Check css={svgContainer} />
-                    모집중인 동아리만 보기
-                </Button>
+
+                <div css={categoryProgressContainer}>
+                    <Button
+                        variant="text"
+                        size="md"
+                        sx={progressContainer(isProgress)}
+                        onClick={() => setIsProgress((prev) => !prev)}
+                    >
+                        <Check css={svgContainer} />
+                        모집중인 동아리만 보기
+                    </Button>
+                    <Dropdown sx={categoryDropdown}>
+                        <Dropdown.Trigger sx={{ border: 'none', backgroundColor: 'transparent' }}>
+                            <Text type="captionSemibold" color="caption">
+                                {currentCategory.name === '전체'
+                                    ? '카테고리'
+                                    : currentCategory.name}
+                            </Text>
+                        </Dropdown.Trigger>
+                        <Dropdown.Content sx={{ border: 'none' }}>
+                            <Dropdown.Item sx={dropdownItem}>
+                                {CLUB_CATEGORIES.map((category) => (
+                                    <Dropdown.Label
+                                        key={category.name}
+                                        onClick={() => handleCategory(category)}
+                                    >
+                                        {category.name}
+                                    </Dropdown.Label>
+                                ))}
+                            </Dropdown.Item>
+                        </Dropdown.Content>
+                    </Dropdown>
+                </div>
             </div>
             <div css={{ padding: '0 0.5rem' }}>
                 <div css={divider}>

--- a/monorepo/apps/user/src/router.tsx
+++ b/monorepo/apps/user/src/router.tsx
@@ -1,6 +1,6 @@
 import { ClubApplyPage } from '@pages/ClubApplyPage';
 import React, { lazy, Suspense } from 'react';
-import { createBrowserRouter } from 'react-router';
+import { createBrowserRouter, ScrollRestoration } from 'react-router';
 
 import { UserLayout } from './layouts';
 import {
@@ -19,7 +19,12 @@ const LazyDetailPage = lazy(() => import('./pages/ClubDetailPage/ClubDetailPage'
 const router = createBrowserRouter([
     {
         path: '/',
-        element: <UserLayout />,
+        element: (
+            <>
+                <UserLayout />
+                <ScrollRestoration />
+            </>
+        ),
         children: [
             {
                 index: true,

--- a/monorepo/apps/user/src/types/images.d.ts
+++ b/monorepo/apps/user/src/types/images.d.ts
@@ -2,3 +2,4 @@ declare module '*.png';
 declare module '*.jpg';
 declare module '*.jpeg';
 declare module '*.svg';
+declare module '*.webp';

--- a/monorepo/apps/user/webpack.common.js
+++ b/monorepo/apps/user/webpack.common.js
@@ -23,7 +23,7 @@ module.exports = {
                 use: ['@svgr/webpack'],
             },
             {
-                test: /\.(png|jpe?g|gif)$/,
+                test: /\.(png|jpe?g|gif|webp)$/,
                 type: 'asset/resource',
             },
             {

--- a/monorepo/packages/ui/src/components/Dropdown/Dropdown.styles.ts
+++ b/monorepo/packages/ui/src/components/Dropdown/Dropdown.styles.ts
@@ -38,6 +38,7 @@ export const s_dropdownTrigger = css`
 const baseContent = css`
     z-index: 50;
     min-width: 8rem;
+    isolation: isolate; // stacking context 분리
 
     border: 1px solid ${theme.colors.gray[300]};
     border-radius: 0.6rem;
@@ -71,18 +72,17 @@ export const s_dropdownContent = (
             ? css`
                   top: calc(100% + 0.4rem);
                   left: 50%;
-                  transform: translateX(-50%) translateY(${y});
+                  transform: translateX(calc(-50% + ${x})) translateY(${y});
               `
             : css`
                   top: 50%;
                   left: calc(100% + 0.4rem);
-                  transform: translateY(-50%) translateX(${x});
+                  transform: translateY(calc(-50% + ${y})) translateX(${x});
               `;
-
     return css`
         ${baseContent}
         position: absolute;
-        ${positionStyles}
+        //${positionStyles}
         opacity: 0;
         pointer-events: none;
         visibility: hidden;


### PR DESCRIPTION
## 📌 관련 이슈 
ex) `closed #351 `

## 🛠️ 작업 내용
PR에서 작업한 주요 내용을 적어주세요.
- [ ] 유저 메인페이지 모바일화면에서 분류 기능 구현
- [ ] 관리자 페이지 이미지 로딩시간 단축하기
- [ ] 카드 컴포넌트 모바일에서 글자 줄일 수 있도록 리팩토링
- [ ] 유저 페이지 헤더 수정

## ⏳ 작업 시간
추정 시간:   4시간
실제 시간:   4시간
