### PR TITLE
[BE] 서버 500 에러 시 Discord 알림 구현

### DIFF
--- a/server/src/main/java/com/ryc/api/v2/club/service/ClubService.java
+++ b/server/src/main/java/com/ryc/api/v2/club/service/ClubService.java
@@ -163,6 +163,7 @@ public class ClubService {
         .build();
   }
 
+  @Transactional
   public List<DetailClubResponse> createDetailClubResponses(List<Club> clubs) {
     List<FileMetaData> fileMetaData =
         fileService.findAllByAssociatedIdIn(clubs.stream().map(Club::getId).toList());

--- a/server/src/main/java/com/ryc/api/v2/common/dispatch/DiscordNotifier.java
+++ b/server/src/main/java/com/ryc/api/v2/common/dispatch/DiscordNotifier.java
@@ -1,0 +1,45 @@
+package com.ryc.api.v2.common.dispatch;
+
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.event.EventListener;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import com.ryc.api.v2.common.exception.event.ServerErrorEvent;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class DiscordNotifier {
+
+  private final String webhookUrl;
+  private final RestTemplate restTemplate = new RestTemplate();
+
+  public DiscordNotifier(@Value("${DISCORD_HOOK_URL}") String webhookUrl) {
+    this.webhookUrl = webhookUrl;
+  }
+
+  @EventListener
+  @Async
+  protected void handleServerErrorEvent(ServerErrorEvent event) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+
+    Map<String, Object> payload = Map.of("content", event.getMessage());
+
+    HttpEntity<Map<String, Object>> request = new HttpEntity<>(payload, headers);
+    try {
+      restTemplate.postForEntity(webhookUrl, request, String.class);
+      log.info("Sent Discord Webhook Message: {}", payload.get("content"));
+    } catch (Exception e) {
+      log.error("Failed to send Discord notification: {}", e.getMessage());
+    }
+  }
+}

--- a/server/src/main/java/com/ryc/api/v2/common/dispatch/EmailSenderService.java
+++ b/server/src/main/java/com/ryc/api/v2/common/dispatch/EmailSenderService.java
@@ -1,4 +1,4 @@
-package com.ryc.api.v2.email.service;
+package com.ryc.api.v2.common.dispatch;
 
 import java.util.List;
 
@@ -9,16 +9,17 @@ import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
 import com.ryc.api.v2.email.domain.Email;
 import com.ryc.api.v2.email.domain.EmailSentStatus;
+import com.ryc.api.v2.email.service.EmailService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@Service
+@Component
 @RequiredArgsConstructor
 public class EmailSenderService {
 

--- a/server/src/main/java/com/ryc/api/v2/common/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/ryc/api/v2/common/exception/GlobalExceptionHandler.java
@@ -64,8 +64,14 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
   }
 
   @ExceptionHandler(BusinessRuleException.class)
-  public ResponseEntity<Object> handleBusinessRuleException(BusinessRuleException e) {
+  public ResponseEntity<Object> handleBusinessRuleException(
+      BusinessRuleException e, HttpServletRequest request) {
     ErrorCode errorCode = e.getErrorCode();
+
+    if (errorCode.getHttpStatus() == HttpStatus.INTERNAL_SERVER_ERROR) {
+      eventPublisher.publishEvent(
+          new ServerErrorEvent(request.getRequestURI(), e.getFormattedMessage()));
+    }
 
     ErrorResponse errorResponse =
         ErrorResponse.builder().code(errorCode.name()).message(e.getFormattedMessage()).build();

--- a/server/src/main/java/com/ryc/api/v2/common/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/ryc/api/v2/common/exception/GlobalExceptionHandler.java
@@ -4,11 +4,14 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
@@ -21,35 +24,43 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 import com.ryc.api.v2.common.exception.code.CommonErrorCode;
 import com.ryc.api.v2.common.exception.code.ErrorCode;
 import com.ryc.api.v2.common.exception.custom.*;
+import com.ryc.api.v2.common.exception.event.ServerErrorEvent;
 import com.ryc.api.v2.common.exception.response.ErrorResponse;
 
+import lombok.RequiredArgsConstructor;
+
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
+  private final ApplicationEventPublisher eventPublisher;
+
   @ExceptionHandler(NoPermissionException.class)
-  public ResponseEntity<Object> handleNoPermissionException(NoPermissionException e) {
+  public ResponseEntity<Object> handleNoPermissionException(
+      NoPermissionException e, HttpServletRequest request) {
     ErrorCode errorCode = e.getErrorCode();
-    return handleExceptionInternal(errorCode);
+    return handleExceptionInternal(errorCode, request);
   }
 
   @ExceptionHandler(ClubException.class)
-  public ResponseEntity<Object> handleClubException(ClubException e) {
+  public ResponseEntity<Object> handleClubException(ClubException e, HttpServletRequest request) {
     ErrorCode errorCode = e.getErrorCode();
-    return handleExceptionInternal(errorCode);
+    return handleExceptionInternal(errorCode, request);
   }
 
   @ExceptionHandler(InterviewException.class)
-  public ResponseEntity<Object> handleInterviewException(InterviewException e) {
+  public ResponseEntity<Object> handleInterviewException(
+      InterviewException e, HttpServletRequest request) {
     ErrorCode errorCode = e.getErrorCode();
-    return handleExceptionInternal(errorCode);
+    return handleExceptionInternal(errorCode, request);
   }
 
   // DataIntegrityViolationException은 JPA에서 중복된 데이터 삽입 시 발생하는 예외
   @ExceptionHandler(DataIntegrityViolationException.class)
   public ResponseEntity<Object> handleDataIntegrityViolationException(
-      DataIntegrityViolationException e) {
+      DataIntegrityViolationException e, HttpServletRequest request) {
     ErrorCode errorCode = CommonErrorCode.DUPLICATE_RESOURCE;
-    return handleExceptionInternal(errorCode);
+    return handleExceptionInternal(errorCode, e.getMessage(), request);
   }
 
   @ExceptionHandler(BusinessRuleException.class)
@@ -64,33 +75,38 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
   // EmptyResultDataAccessException은 JPA에서 존재하지 않는 데이터를 삭제하려고 할 때 발생하는 예외
   @ExceptionHandler(EmptyResultDataAccessException.class)
-  public ResponseEntity<Object> handleEmptyResult(EmptyResultDataAccessException e) {
+  public ResponseEntity<Object> handleEmptyResult(
+      EmptyResultDataAccessException e, HttpServletRequest request) {
     ErrorCode errorCode = CommonErrorCode.RESOURCE_NOT_FOUND;
-    return handleExceptionInternal(errorCode);
+    return handleExceptionInternal(errorCode, e.getMessage(), request);
   }
 
   @ExceptionHandler(NoSuchElementException.class)
-  public ResponseEntity<Object> handleNoSuchElementException(NoSuchElementException e) {
+  public ResponseEntity<Object> handleNoSuchElementException(
+      NoSuchElementException e, HttpServletRequest request) {
     ErrorCode errorCode = CommonErrorCode.RESOURCE_NOT_FOUND;
-    return handleExceptionInternal(errorCode, e.getMessage());
+    return handleExceptionInternal(errorCode, e.getMessage(), request);
   }
 
   @ExceptionHandler(IllegalArgumentException.class)
-  public ResponseEntity<Object> handleIllegalArgumentException(IllegalArgumentException e) {
+  public ResponseEntity<Object> handleIllegalArgumentException(
+      IllegalArgumentException e, HttpServletRequest request) {
     ErrorCode errorCode = CommonErrorCode.INVALID_PARAMETER;
-    return handleExceptionInternal(errorCode, e.getMessage());
+    return handleExceptionInternal(errorCode, e.getMessage(), request);
   }
 
   @ExceptionHandler(ConstraintViolationException.class)
-  public ResponseEntity<Object> handleConstraintViolationException(ConstraintViolationException e) {
+  public ResponseEntity<Object> handleConstraintViolationException(
+      ConstraintViolationException e, HttpServletRequest request) {
     ErrorCode errorCode = CommonErrorCode.INVALID_PARAMETER;
-    return handleExceptionInternal(errorCode, e.getMessage());
+    return handleExceptionInternal(errorCode, e.getMessage(), request);
   }
 
   @ExceptionHandler(InvalidFormatException.class)
-  public ResponseEntity<Object> handleInvalidFormatException(InvalidFormatException e) {
+  public ResponseEntity<Object> handleInvalidFormatException(
+      InvalidFormatException e, HttpServletRequest request) {
     ErrorCode errorCode = e.getErrorCode();
-    return handleExceptionInternal(errorCode);
+    return handleExceptionInternal(errorCode, request);
   }
 
   @Override
@@ -104,17 +120,28 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
   }
 
   @ExceptionHandler({Exception.class})
-  public ResponseEntity<Object> handleAllExceptions(Exception e) {
+  public ResponseEntity<Object> handleAllExceptions(Exception e, HttpServletRequest request) {
     ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
-    return handleExceptionInternal(errorCode, e.getMessage());
+    return handleExceptionInternal(errorCode, e.getMessage(), request);
   }
 
   // handleExceptionInternal Method
-  private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode) {
+  private ResponseEntity<Object> handleExceptionInternal(
+      ErrorCode errorCode, HttpServletRequest request) {
+
+    if (errorCode.getHttpStatus() == HttpStatus.INTERNAL_SERVER_ERROR) {
+      eventPublisher.publishEvent(
+          new ServerErrorEvent(request.getRequestURI(), errorCode.getMessage()));
+    }
     return ResponseEntity.status(errorCode.getHttpStatus()).body(makeErrorResponse(errorCode));
   }
 
-  private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode, String message) {
+  private ResponseEntity<Object> handleExceptionInternal(
+      ErrorCode errorCode, String message, HttpServletRequest request) {
+
+    if (errorCode.getHttpStatus() == HttpStatus.INTERNAL_SERVER_ERROR) {
+      eventPublisher.publishEvent(new ServerErrorEvent(request.getRequestURI(), message));
+    }
     return ResponseEntity.status(errorCode.getHttpStatus())
         .body(makeErrorResponse(errorCode, message));
   }

--- a/server/src/main/java/com/ryc/api/v2/common/exception/event/ServerErrorEvent.java
+++ b/server/src/main/java/com/ryc/api/v2/common/exception/event/ServerErrorEvent.java
@@ -1,0 +1,19 @@
+package com.ryc.api.v2.common.exception.event;
+
+import lombok.Getter;
+
+@Getter
+public class ServerErrorEvent {
+
+  private final String message;
+
+  public ServerErrorEvent(String requestUri, String message) {
+    this.message =
+        """
+      ❗️[서버 오류] 500 오류 발생
+      ➤ 요청 URL: %s
+      ➤ 예외 메시지: %s
+      """
+            .formatted(requestUri, message);
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
close #402 

## 🛠️ 작업 내용
- [ ] 500 Server Error 시 `Discord에 알림 발송 기능` 구현
- [ ] 기존에 외부 I/O 작업을 수행하는 `EmailSenderService 클래스`를 `dispatch 패키지`로 이동

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 서버 오류 발생 시 디스코드 웹훅으로 운영 알림을 비동기로 전송하여 장애 인지 속도 향상.
- 리팩터링
  - 예외 처리 흐름을 요청 컨텍스트 기반으로 일원화해 오류 추적성과 응답 일관성 강화.
  - 일부 서비스 트랜잭션 경계를 조정해 처리 안정성 개선.
- 작업
  - 알림/메일 발송 관련 컴포넌트 구조를 정리해 모듈화 및 유지보수성 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->