### PR TITLE
[BE] 나의 동아리 조회 API 응답 값 수정

### DIFF
--- a/server/src/main/java/com/ryc/api/v2/club/infra/projection/MyClubProjection.java
+++ b/server/src/main/java/com/ryc/api/v2/club/infra/projection/MyClubProjection.java
@@ -1,0 +1,11 @@
+package com.ryc.api.v2.club.infra.projection;
+
+import com.ryc.api.v2.club.infra.entity.ClubEntity;
+import com.ryc.api.v2.role.domain.enums.Role;
+
+public interface MyClubProjection {
+
+  ClubEntity getClub();
+
+  Role getRole();
+}

--- a/server/src/main/java/com/ryc/api/v2/club/presentation/ClubHttpApi.java
+++ b/server/src/main/java/com/ryc/api/v2/club/presentation/ClubHttpApi.java
@@ -15,6 +15,7 @@ import com.ryc.api.v2.club.presentation.dto.request.ClubCreateRequest;
 import com.ryc.api.v2.club.presentation.dto.request.ClubUpdateRequest;
 import com.ryc.api.v2.club.presentation.dto.response.ClubCreateResponse;
 import com.ryc.api.v2.club.presentation.dto.response.DetailClubResponse;
+import com.ryc.api.v2.club.presentation.dto.response.MyClubGetResponse;
 import com.ryc.api.v2.club.presentation.dto.response.SimpleClubResponse;
 import com.ryc.api.v2.club.service.ClubFacade;
 import com.ryc.api.v2.common.aop.annotation.HasRole;
@@ -94,9 +95,9 @@ public class ClubHttpApi {
 
   @GetMapping("/my")
   @Operation(summary = "사용자가 속한 동아리 조회 API", description = "사용자가 속한 동아리들을 조회합니다.")
-  public ResponseEntity<List<DetailClubResponse>> getMyClubs(
+  public ResponseEntity<List<MyClubGetResponse>> getMyClubs(
       @AuthenticationPrincipal CustomUserDetail userDetail) {
-    List<DetailClubResponse> responses = clubFacade.getMyClubs(userDetail.getId());
+    List<MyClubGetResponse> responses = clubFacade.getMyClubs(userDetail.getId());
     return ResponseEntity.status(HttpStatus.OK).body(responses);
   }
 

--- a/server/src/main/java/com/ryc/api/v2/club/presentation/dto/response/MyClubGetResponse.java
+++ b/server/src/main/java/com/ryc/api/v2/club/presentation/dto/response/MyClubGetResponse.java
@@ -1,0 +1,9 @@
+package com.ryc.api.v2.club.presentation.dto.response;
+
+import com.ryc.api.v2.role.domain.enums.Role;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MyClubGetResponse(
+    @Schema(description = "나의 동아리 데이터") DetailClubResponse myClubResponse,
+    @Schema(description = "나의 역할") Role myRole) {}

--- a/server/src/main/java/com/ryc/api/v2/club/service/ClubService.java
+++ b/server/src/main/java/com/ryc/api/v2/club/service/ClubService.java
@@ -9,13 +9,12 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.ryc.api.v2.announcement.domain.enums.AnnouncementStatus;
 import com.ryc.api.v2.club.domain.Club;
 import com.ryc.api.v2.club.domain.ClubRepository;
 import com.ryc.api.v2.club.presentation.dto.request.ClubCreateRequest;
 import com.ryc.api.v2.club.presentation.dto.request.ClubUpdateRequest;
 import com.ryc.api.v2.club.presentation.dto.response.DetailClubResponse;
-import com.ryc.api.v2.club.presentation.dto.response.SimpleClubResponse;
+import com.ryc.api.v2.club.service.dto.ClubImageDTO;
 import com.ryc.api.v2.common.dto.response.FileGetResponse;
 import com.ryc.api.v2.common.exception.code.ClubErrorCode;
 import com.ryc.api.v2.common.exception.custom.ClubException;
@@ -72,31 +71,8 @@ public class ClubService {
     fileService.claimOwnership(
         body.representativeImage(), savedClub.getId(), FileDomainType.CLUB_PROFILE);
 
-    List<FileMetaData> images = fileService.findAllByAssociatedId(savedClub.getId());
-    FileGetResponse representativeImage =
-        images.stream()
-            .filter(image -> image.getFileDomainType() == FileDomainType.CLUB_PROFILE)
-            .findFirst()
-            .map(image -> FileGetResponse.of(image, fileService.getPublicFileGetUrl(image)))
-            .orElse(null);
-
-    List<FileGetResponse> detailImages =
-        images.stream()
-            .filter(image -> image.getFileDomainType() == FileDomainType.CLUB_IMAGE)
-            .map(image -> FileGetResponse.of(image, fileService.getPublicFileGetUrl(image)))
-            .toList();
-
-    return DetailClubResponse.builder()
-        .id(savedClub.getId())
-        .name(savedClub.getName())
-        .representativeImage(representativeImage)
-        .shortDescription(savedClub.getShortDescription())
-        .detailDescription(savedClub.getDetailDescription())
-        .category(savedClub.getCategory())
-        .clubTags(savedClub.getClubTags())
-        .clubSummaries(savedClub.getClubSummaries())
-        .clubDetailImages(detailImages)
-        .build();
+    ClubImageDTO clubImageResponse = getClubImageDTO(savedClub.getId());
+    return createDetailClubResponse(savedClub, clubImageResponse);
   }
 
   @Transactional(readOnly = true)
@@ -108,32 +84,8 @@ public class ClubService {
   public DetailClubResponse getClub(String clubId) {
     Club club = clubRepository.findById(clubId);
 
-    List<FileMetaData> images = fileService.findAllByAssociatedId(clubId);
-
-    FileGetResponse representativeImage =
-        images.stream()
-            .filter(image -> image.getFileDomainType() == FileDomainType.CLUB_PROFILE)
-            .findFirst()
-            .map(image -> FileGetResponse.of(image, fileService.getPublicFileGetUrl(image)))
-            .orElse(null);
-
-    List<FileGetResponse> detailImages =
-        images.stream()
-            .filter(image -> image.getFileDomainType() == FileDomainType.CLUB_IMAGE)
-            .map(image -> FileGetResponse.of(image, fileService.getPublicFileGetUrl(image)))
-            .toList();
-
-    return DetailClubResponse.builder()
-        .id(club.getId())
-        .name(club.getName())
-        .shortDescription(club.getShortDescription())
-        .detailDescription(club.getDetailDescription())
-        .category(club.getCategory())
-        .clubTags(club.getClubTags())
-        .clubSummaries(club.getClubSummaries())
-        .representativeImage(representativeImage)
-        .clubDetailImages(detailImages)
-        .build();
+    ClubImageDTO clubImageResponse = getClubImageDTO(clubId);
+    return createDetailClubResponse(club, clubImageResponse);
   }
 
   @Transactional(readOnly = true)
@@ -146,35 +98,7 @@ public class ClubService {
     clubRepository.deleteById(id);
   }
 
-  public SimpleClubResponse createSimpleClubResponse(
-      Club club, Map<String, AnnouncementStatus> statuses) {
-    AnnouncementStatus status;
-
-    if (statuses != null && statuses.containsKey(club.getId())) {
-      status = statuses.get(club.getId());
-    } else {
-      status = null;
-    }
-
-    FileGetResponse representativeImageResponse =
-        fileService.findAllByAssociatedId(club.getId()).stream()
-            .filter(image -> image.getFileDomainType() == FileDomainType.CLUB_PROFILE)
-            .findFirst()
-            .map(image -> FileGetResponse.of(image, fileService.getPublicFileGetUrl(image)))
-            .orElse(null);
-
-    return SimpleClubResponse.builder()
-        .id(club.getId())
-        .name(club.getName())
-        .shortDescription(club.getShortDescription())
-        .representativeImage(representativeImageResponse)
-        .category(club.getCategory())
-        .clubTags(club.getClubTags())
-        .announcementStatus(status)
-        .build();
-  }
-
-  @Transactional
+  @Transactional(readOnly = true)
   public List<DetailClubResponse> createDetailClubResponses(List<Club> clubs) {
     List<FileMetaData> fileMetaData =
         fileService.findAllByAssociatedIdIn(clubs.stream().map(Club::getId).toList());
@@ -212,5 +136,38 @@ public class ClubService {
                     .clubDetailImages(detailImageMap.get(club.getId()))
                     .build())
         .toList();
+  }
+
+  public ClubImageDTO getClubImageDTO(String clubId) {
+    List<FileMetaData> images = fileService.findAllByAssociatedId(clubId);
+
+    FileGetResponse profileImage =
+        images.stream()
+            .filter(image -> image.getFileDomainType() == FileDomainType.CLUB_PROFILE)
+            .findFirst()
+            .map(image -> FileGetResponse.of(image, fileService.getPublicFileGetUrl(image)))
+            .orElse(null);
+
+    List<FileGetResponse> detailImages =
+        images.stream()
+            .filter(image -> image.getFileDomainType() == FileDomainType.CLUB_IMAGE)
+            .map(image -> FileGetResponse.of(image, fileService.getPublicFileGetUrl(image)))
+            .toList();
+
+    return new ClubImageDTO(profileImage, detailImages);
+  }
+
+  public DetailClubResponse createDetailClubResponse(Club club, ClubImageDTO clubImageResponse) {
+    return DetailClubResponse.builder()
+        .id(club.getId())
+        .name(club.getName())
+        .shortDescription(club.getShortDescription())
+        .detailDescription(club.getDetailDescription())
+        .category(club.getCategory())
+        .clubTags(club.getClubTags())
+        .clubSummaries(club.getClubSummaries())
+        .representativeImage(clubImageResponse.profileImage())
+        .clubDetailImages(clubImageResponse.detailImages())
+        .build();
   }
 }

--- a/server/src/main/java/com/ryc/api/v2/club/service/dto/ClubImageDTO.java
+++ b/server/src/main/java/com/ryc/api/v2/club/service/dto/ClubImageDTO.java
@@ -4,4 +4,5 @@ import java.util.List;
 
 import com.ryc.api.v2.common.dto.response.FileGetResponse;
 
-public record ClubImageDTO(FileGetResponse profileImage, List<FileGetResponse> detailImages) {}
+public record ClubImageDTO(
+    FileGetResponse representativeImage, List<FileGetResponse> detailImages) {}

--- a/server/src/main/java/com/ryc/api/v2/club/service/dto/ClubImageDTO.java
+++ b/server/src/main/java/com/ryc/api/v2/club/service/dto/ClubImageDTO.java
@@ -1,0 +1,7 @@
+package com.ryc.api.v2.club.service.dto;
+
+import java.util.List;
+
+import com.ryc.api.v2.common.dto.response.FileGetResponse;
+
+public record ClubImageDTO(FileGetResponse profileImage, List<FileGetResponse> detailImages) {}

--- a/server/src/main/java/com/ryc/api/v2/club/service/dto/MyClubDTO.java
+++ b/server/src/main/java/com/ryc/api/v2/club/service/dto/MyClubDTO.java
@@ -1,0 +1,6 @@
+package com.ryc.api.v2.club.service.dto;
+
+import com.ryc.api.v2.club.domain.Club;
+import com.ryc.api.v2.role.domain.enums.Role;
+
+public record MyClubDTO(Club club, Role role) {}

--- a/server/src/main/java/com/ryc/api/v2/role/domain/ClubRoleRepository.java
+++ b/server/src/main/java/com/ryc/api/v2/role/domain/ClubRoleRepository.java
@@ -3,7 +3,7 @@ package com.ryc.api.v2.role.domain;
 import java.util.List;
 import java.util.Optional;
 
-import com.ryc.api.v2.club.domain.Club;
+import com.ryc.api.v2.club.service.dto.MyClubDTO;
 
 public interface ClubRoleRepository {
 
@@ -13,7 +13,7 @@ public interface ClubRoleRepository {
 
   List<ClubRole> findRolesByClubId(String clubId);
 
-  List<Club> findClubsByAdminId(String adminId);
+  List<MyClubDTO> findMyClubsByAdminId(String adminId);
 
   Optional<ClubInvite> findInviteOptionalByClubId(String clubId);
 

--- a/server/src/main/java/com/ryc/api/v2/role/infra/ClubRoleRepositoryImpl.java
+++ b/server/src/main/java/com/ryc/api/v2/role/infra/ClubRoleRepositoryImpl.java
@@ -6,9 +6,9 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
-import com.ryc.api.v2.club.domain.Club;
-import com.ryc.api.v2.club.infra.entity.ClubEntity;
 import com.ryc.api.v2.club.infra.mapper.ClubMapper;
+import com.ryc.api.v2.club.infra.projection.MyClubProjection;
+import com.ryc.api.v2.club.service.dto.MyClubDTO;
 import com.ryc.api.v2.role.domain.ClubInvite;
 import com.ryc.api.v2.role.domain.ClubRole;
 import com.ryc.api.v2.role.domain.ClubRoleRepository;
@@ -49,9 +49,11 @@ public class ClubRoleRepositoryImpl implements ClubRoleRepository {
   }
 
   @Override
-  public List<Club> findClubsByAdminId(String adminId) {
-    List<ClubEntity> clubEntities = clubRoleJpaRepository.findClubsByAdminId(adminId);
-    return clubEntities.stream().map(ClubMapper::toDomain).toList();
+  public List<MyClubDTO> findMyClubsByAdminId(String adminId) {
+    List<MyClubProjection> projections = clubRoleJpaRepository.findClubsAndRolesByAdmin_Id(adminId);
+    return projections.stream()
+        .map(p -> new MyClubDTO(ClubMapper.toDomain(p.getClub()), p.getRole()))
+        .toList();
   }
 
   @Override
@@ -74,7 +76,7 @@ public class ClubRoleRepositoryImpl implements ClubRoleRepository {
 
   @Override
   public boolean existsOwnerRoleByAdminIdAndClubId(String adminId, String clubId) {
-    return clubRoleJpaRepository.existsOwnerRoleByAdminIdAndClubId(adminId, clubId);
+    return clubRoleJpaRepository.existsOwnerRoleByAdmin_IdAndClub_Id(adminId, clubId);
   }
 
   @Override

--- a/server/src/main/java/com/ryc/api/v2/role/infra/jpa/ClubRoleJpaRepository.java
+++ b/server/src/main/java/com/ryc/api/v2/role/infra/jpa/ClubRoleJpaRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import com.ryc.api.v2.club.infra.entity.ClubEntity;
+import com.ryc.api.v2.club.infra.projection.MyClubProjection;
 import com.ryc.api.v2.role.infra.entity.ClubRoleEntity;
 
 public interface ClubRoleJpaRepository extends JpaRepository<ClubRoleEntity, String> {
@@ -23,7 +23,7 @@ public interface ClubRoleJpaRepository extends JpaRepository<ClubRoleEntity, Str
           WHERE r.admin.id = :adminId AND r.club.id = :clubId AND r.role = 'OWNER'
         ) THEN true ELSE false END
       """)
-  boolean existsOwnerRoleByAdminIdAndClubId(
+  boolean existsOwnerRoleByAdmin_IdAndClub_Id(
       @Param("adminId") String adminId, @Param("clubId") String clubId);
 
   boolean existsByClub_Id(String clubId);
@@ -39,13 +39,12 @@ public interface ClubRoleJpaRepository extends JpaRepository<ClubRoleEntity, Str
 
   void deleteByAdmin_IdAndClub_Id(String adminId, String clubId);
 
-  @Query(
-      """
-        SELECT c FROM ClubRoleEntity r
-        JOIN r.club c
-        WHERE r.admin.id = :adminId
-      """)
-  List<ClubEntity> findClubsByAdminId(String adminId);
+  @Query("""
+  SELECT r FROM ClubRoleEntity r
+  JOIN FETCH r.club
+  WHERE r.admin.id = :adminId
+""")
+  List<MyClubProjection> findClubsAndRolesByAdmin_Id(String adminId);
 
   void deleteByClub_Id(String clubId);
 

--- a/server/src/main/java/com/ryc/api/v2/role/infra/jpa/ClubRoleJpaRepository.java
+++ b/server/src/main/java/com/ryc/api/v2/role/infra/jpa/ClubRoleJpaRepository.java
@@ -39,11 +39,12 @@ public interface ClubRoleJpaRepository extends JpaRepository<ClubRoleEntity, Str
 
   void deleteByAdmin_IdAndClub_Id(String adminId, String clubId);
 
-  @Query("""
-  SELECT r FROM ClubRoleEntity r
-  JOIN FETCH r.club
-  WHERE r.admin.id = :adminId
-""")
+  @Query(
+      """
+    SELECT r.club AS club, r.role AS role
+    FROM ClubRoleEntity r
+    WHERE r.admin.id = :adminId
+  """)
   List<MyClubProjection> findClubsAndRolesByAdmin_Id(String adminId);
 
   void deleteByClub_Id(String clubId);

--- a/server/src/main/java/com/ryc/api/v2/role/service/ClubRoleService.java
+++ b/server/src/main/java/com/ryc/api/v2/role/service/ClubRoleService.java
@@ -17,6 +17,7 @@ import com.ryc.api.v2.admin.service.AdminService;
 import com.ryc.api.v2.club.domain.Club;
 import com.ryc.api.v2.club.domain.ClubRepository;
 import com.ryc.api.v2.club.domain.event.ClubDeletedEvent;
+import com.ryc.api.v2.club.service.dto.MyClubDTO;
 import com.ryc.api.v2.common.dto.response.FileGetResponse;
 import com.ryc.api.v2.common.exception.code.ClubErrorCode;
 import com.ryc.api.v2.common.exception.custom.ClubException;
@@ -149,8 +150,8 @@ public class ClubRoleService {
   }
 
   @Transactional(readOnly = true)
-  public List<Club> getMyClubs(String adminId) {
-    return clubRoleRepository.findClubsByAdminId(adminId);
+  public List<MyClubDTO> getMyClubs(String adminId) {
+    return clubRoleRepository.findMyClubsByAdminId(adminId);
   }
 
   @Transactional(readOnly = true)


### PR DESCRIPTION
## 📌 관련 이슈
close #431 

## 🛠️ 작업 내용
- [ ] 작업1
- [ ] 작업2

## 🎯 리뷰 포인트
리뷰시 중점적으로 봐주었으면 좋을 부분을 적어주세요.  
없다면 적지 않아도 됩니다.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 내 동아리 목록 API가 동아리 정보와 함께 사용자의 역할을 함께 반환합니다.
  * 동아리 리스트와 초대코드로 조회한 동아리 응답에 대표 이미지(및 상세 이미지)가 포함되어 시각 정보가 개선되었습니다.
  * 상세/목록 응답 전반에서 이미지 정보를 일관되게 제공하도록 응답 구조가 개선되었습니다.
  * 공지 상태를 포함한 전체 동아리 조회에서도 대표 이미지가 함께 제공되어 탐색성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->