### PR TITLE
[BE/HOTFIX] 공고 업데이트시 CreatedAt Null값 입력시 도메인검증 예외 수정

### DIFF
--- a/server/src/main/java/com/ryc/api/v2/announcement/domain/AnnouncementValidator.java
+++ b/server/src/main/java/com/ryc/api/v2/announcement/domain/AnnouncementValidator.java
@@ -10,7 +10,6 @@ import com.ryc.api.v2.announcement.domain.enums.AnnouncementStatus;
 import com.ryc.api.v2.announcement.domain.enums.AnnouncementType;
 import com.ryc.api.v2.announcement.domain.vo.AnnouncementPeriodInfo;
 import com.ryc.api.v2.applicationForm.domain.ApplicationForm;
-import com.ryc.api.v2.common.constant.DomainDefaultValues;
 import com.ryc.api.v2.common.domain.Tag;
 import com.ryc.api.v2.common.validator.DomainValidator;
 
@@ -173,15 +172,9 @@ final class AnnouncementValidator extends DomainValidator {
     validateNotNull(applicationForm, ANNOUNCEMENT_APPLICATION_FORM_NULL);
   }
 
-  private static void validateCreatedAt(String id, LocalDateTime createdAt) {
-    // 영속화 이전은 NULL 허용
-    if (id.equals(DomainDefaultValues.DEFAULT_INITIAL_ID)) return;
-    validateNotNull(createdAt, ANNOUNCEMENT_CREATED_AT_NULL);
-  }
+  // 영속성 레이어를 거친 경우에만 service에서 상태검증으로 null 제한 체크
+  private static void validateCreatedAt(String id, LocalDateTime createdAt) {}
 
-  private static void validateUpdatedAt(String id, LocalDateTime updatedAt) {
-    // 영속화 이전은 NULL 허용
-    if (id.equals(DomainDefaultValues.DEFAULT_INITIAL_ID)) return;
-    validateNotNull(updatedAt, ANNOUNCEMENT_UPDATED_AT_NULL);
-  }
+  // 영속성 레이어를 거친 경우에만 service에서 상태검증으로 null 제한 체크
+  private static void validateUpdatedAt(String id, LocalDateTime updatedAt) {}
 }

--- a/server/src/main/java/com/ryc/api/v2/application/domain/ApplicationValidator.java
+++ b/server/src/main/java/com/ryc/api/v2/application/domain/ApplicationValidator.java
@@ -6,7 +6,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import com.ryc.api.v2.common.constant.DomainDefaultValues;
 import com.ryc.api.v2.common.validator.DomainValidator;
 
 /** 유효성(Validation) 검사 Util 클래스 접근 제한자 package-private 준수 */
@@ -48,9 +47,6 @@ final class ApplicationValidator extends DomainValidator {
     validateNotNull(answers, APPLICATION_ANSWERS_NULL);
   }
 
-  private static void validateCreatedAt(String id, LocalDateTime createdAt) {
-    // 영속화 이전은 NULL 허용
-    if (id.equals(DomainDefaultValues.DEFAULT_INITIAL_ID)) return;
-    validateNotNull(createdAt, APPLICATION_CREATED_AT_NULL);
-  }
+  // 영속성 레이어를 거친 경우에만 service에서 상태검증으로 null 제한 체크
+  private static void validateCreatedAt(String id, LocalDateTime createdAt) {}
 }

--- a/server/src/main/java/com/ryc/api/v2/evaluation/domain/EvaluationValidator.java
+++ b/server/src/main/java/com/ryc/api/v2/evaluation/domain/EvaluationValidator.java
@@ -6,7 +6,6 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.regex.Pattern;
 
-import com.ryc.api.v2.common.constant.DomainDefaultValues;
 import com.ryc.api.v2.common.validator.DomainValidator;
 
 /** 유효성(Validation) 검사 Util 클래스 접근 제한자 package-private 준수 */
@@ -83,15 +82,9 @@ final class EvaluationValidator extends DomainValidator {
     validateNotNull(type, EVALUATION_TYPE_NULL);
   }
 
-  private static void validateCreatedAt(String id, LocalDateTime createdAt) {
-    // 영속화 이전은 NULL 허용
-    if (id.equals(DomainDefaultValues.DEFAULT_INITIAL_ID)) return;
-    validateNotNull(createdAt, EVALUATION_CREATED_AT_NULL);
-  }
+  // 영속성 레이어를 거친 경우에만 service에서 상태검증으로 null 제한 체크
+  private static void validateCreatedAt(String id, LocalDateTime createdAt) {}
 
-  private static void validateUpdatedAt(String id, LocalDateTime updatedAt) {
-    // 영속화 이전은 NULL 허용
-    if (id.equals(DomainDefaultValues.DEFAULT_INITIAL_ID)) return;
-    validateNotNull(updatedAt, EVALUATION_UPDATED_AT_NULL);
-  }
+  // 영속성 레이어를 거친 경우에만 service에서 상태검증으로 null 제한 체크
+  private static void validateUpdatedAt(String id, LocalDateTime updatedAt) {}
 }

--- a/server/src/main/java/com/ryc/api/v2/file/domain/FileMetaDataValidator.java
+++ b/server/src/main/java/com/ryc/api/v2/file/domain/FileMetaDataValidator.java
@@ -112,9 +112,8 @@ final class FileMetaDataValidator extends DomainValidator {
     // TODO: 구현필요
   }
 
-  private static void validateCreatedAt(LocalDateTime createdAt) {
-    // TODO: 구현필요
-  }
+  // 영속성 레이어를 거친 경우에만 service에서 상태검증으로 null 제한 체크
+  private static void validateCreatedAt(LocalDateTime createdAt) {}
 
   private static void validateFileDomainType(FileDomainType fileDomainType) {
     validateNotNull(fileDomainType, FILE_METADATA_FILE_DOMAIN_TYPE_NULL);


### PR DESCRIPTION
## 📌 관련 이슈
issue #447 

## 🛠️ 작업 내용
각 도메인 생성 루트에서 createdAt, updatedAt의 초기화 시퀀스는 다음과 같다.
1. 최초 생성시(id:무효, createdAt null허용)
2. 조회시 (id:유효, createdAt null 비허용)
3. 수정시 (id 유효, createdAt null허용)
 
기존에 id:무효상황(즉, DefaultID)인 경우에만 null 허용으로 제한해 두었으나, 3번 수정시 또한 영속성 레이어를 거치지 않아, createdAt을 Null로 열어둬야 하는 상황발생
따라서 현재, 조건분기로 처리할수 있는 기준점이 없기에, 도메인 필드 createdAt, updatedAt를 null로 열어두되, 2번상황인 조회시에는 서비스에서 상태 검증으로 Null 체크를 하는식으로 구성

## ⏳ 작업 시간
추정 시간:   10분
실제 시간:   10분
이유: 차이가 많이 난다면 이유도 같이 적어주세요 :)
