### PR TITLE
[BE/HOTFIX] 요청객체 검증시 400 에러 응답 검증규칙 간극 해결

### DIFF
--- a/server/src/main/java/com/ryc/api/v2/announcement/presentation/dto/request/AnnouncementCreateRequest.java
+++ b/server/src/main/java/com/ryc/api/v2/announcement/presentation/dto/request/AnnouncementCreateRequest.java
@@ -3,10 +3,7 @@ package com.ryc.api.v2.announcement.presentation.dto.request;
 import java.util.List;
 
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 
 import org.hibernate.validator.constraints.UUID;
 
@@ -34,8 +31,7 @@ import lombok.Builder;
 public record AnnouncementCreateRequest(
     @Schema(description = "공고 제목", example = "2025년도 상반기 신입 모집")
         @NotBlank(message = "공고 제목은 필수 항목입니다.")
-        @Min(value = 2, message = "공고 제목의 최소길이는 2자입니다.")
-        @Max(value = 100, message = "공고 제목의 최대길이는 100자입니다.")
+        @Size(min = 2, max = 100, message = "공고 제목의 길이는 2자 이상 100자 이하입니다.")
         String title,
     @Schema(description = "기간 정보")
         @NotNull(message = "공고 기한 정보 필드는 빈값일 수 없습니다. 최소 지원서 접수기간은 필수 입력해주십시오.")
@@ -43,27 +39,27 @@ public record AnnouncementCreateRequest(
         AnnouncementPeriodInfoRequest periodInfo,
     @Schema(description = "모집 인원", example = "10명 이내")
         @NullOrNotBlank
-        @Max(value = 50, message = "모집인원의 최대길이는 50자입니다.")
+        @Size(max = 50, message = "모집인원의 최대길이는 50자입니다.")
         String numberOfPeople,
     @Schema(description = "상세 정보", example = "코딩 동아리에서 신입 qnd 모집합니다. ")
         @NullOrNotBlank
-        @Max(value = 10000, message = "공고 상세 설명은 10000자를 초과할 수 없습니다.")
+        @Size(max = 10000, message = "공고 상세 설명은 10000자를 초과할 수 없습니다.")
         String detailDescription,
     @Schema(description = "요약 소개", example = "코딩 동아리에서 신입 qnd 모집합니다.")
         @NullOrNotBlank
-        @Max(value = 300, message = "공고 요약 설명은 300자를 초과할 수 없습니다.")
+        @Size(max = 300, message = "공고 요약 설명은 300자를 초과할 수 없습니다.")
         String summaryDescription,
     @Schema(description = "활동 기간", example = "2023-01-01 ~ 2023-12-31")
         @NullOrNotBlank
-        @Max(value = 100, message = "활동 기간은 100자를 초과할 수 없습니다.")
+        @Size(max = 100, message = "활동 기간은 100자를 초과할 수 없습니다.")
         String activityPeriod,
     @Schema(description = "모집 대상", example = "컴퓨터공학과 학생")
         @NullOrNotBlank
-        @Max(value = 50, message = "모집 대상은 50자를 초과할 수 없습니다.")
+        @Size(max = 50, message = "모집 대상은 50자를 초과할 수 없습니다.")
         String target,
     @Schema(description = "모집 분야", example = "백엔드")
         @NullOrNotBlank
-        @Max(value = 50, message = "모집 분야는 50자를 초과할 수 없습니다.")
+        @Size(max = 50, message = "모집 분야는 50자를 초과할 수 없습니다.")
         String field,
     @Schema(
             description = "공고 타입",

--- a/server/src/main/java/com/ryc/api/v2/announcement/presentation/dto/request/AnnouncementUpdateRequest.java
+++ b/server/src/main/java/com/ryc/api/v2/announcement/presentation/dto/request/AnnouncementUpdateRequest.java
@@ -3,10 +3,7 @@ package com.ryc.api.v2.announcement.presentation.dto.request;
 import java.util.List;
 
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 
 import org.hibernate.validator.constraints.UUID;
 
@@ -34,8 +31,7 @@ import lombok.Builder;
 public record AnnouncementUpdateRequest(
     @Schema(description = "공고 제목", example = "2025년도 상반기 신입 모집")
         @NotBlank(message = "공고 제목은 필수 항목입니다.")
-        @Min(value = 2, message = "공고 제목의 최소길이는 2자입니다.")
-        @Max(value = 100, message = "공고 제목의 최대길이는 100자입니다.")
+        @Size(min = 2, max = 100, message = "공고 제목의 길이는 2자 이상 100자이하 입니다.")
         String title,
     @Schema(description = "기간 정보")
         @NotNull(message = "공고 기한 정보 필드는 빈값일 수 없습니다. 최소 지원서 접수기간은 필수 입력해주십시오.")
@@ -43,27 +39,27 @@ public record AnnouncementUpdateRequest(
         AnnouncementPeriodInfoRequest periodInfo,
     @Schema(description = "모집 인원", example = "10명 이내")
         @NullOrNotBlank
-        @Max(value = 50, message = "모집인원의 최대길이는 50자입니다.")
+        @Size(max = 50, message = "모집인원의 최대길이는 50자입니다.")
         String numberOfPeople,
     @Schema(description = "상세 정보", example = "코딩 동아리에서 신입 qnd 모집합니다. ")
         @NullOrNotBlank
-        @Max(value = 10000, message = "공고 상세 설명은 10000자를 초과할 수 없습니다.")
+        @Size(max = 10000, message = "공고 상세 설명은 10000자를 초과할 수 없습니다.")
         String detailDescription,
     @Schema(description = "요약 소개", example = "코딩 동아리에서 신입 qnd 모집합니다.")
         @NullOrNotBlank
-        @Max(value = 300, message = "공고 요약 설명은 300자를 초과할 수 없습니다.")
+        @Size(max = 300, message = "공고 요약 설명은 300자를 초과할 수 없습니다.")
         String summaryDescription,
     @Schema(description = "활동 기간", example = "2023-01-01 ~ 2023-12-31")
         @NullOrNotBlank
-        @Max(value = 100, message = "활동 기간은 100자를 초과할 수 없습니다.")
+        @Size(max = 100, message = "활동 기간은 100자를 초과할 수 없습니다.")
         String activityPeriod,
     @Schema(description = "모집 대상", example = "컴퓨터공학과 학생")
         @NullOrNotBlank
-        @Max(value = 50, message = "모집 대상은 50자를 초과할 수 없습니다.")
+        @Size(max = 50, message = "모집 대상은 50자를 초과할 수 없습니다.")
         String target,
     @Schema(description = "모집 분야", example = "백엔드")
         @NullOrNotBlank
-        @Max(value = 50, message = "모집 분야는 50자를 초과할 수 없습니다.")
+        @Size(max = 50, message = "모집 분야는 50자를 초과할 수 없습니다.")
         String field,
     @Schema(
             description = "공고 타입",

--- a/server/src/main/java/com/ryc/api/v2/applicant/presentation/ApplicantHttpApi.java
+++ b/server/src/main/java/com/ryc/api/v2/applicant/presentation/ApplicantHttpApi.java
@@ -18,6 +18,7 @@ import com.ryc.api.v2.common.aop.annotation.HasRole;
 import com.ryc.api.v2.common.exception.annotation.ApiErrorCodeExample;
 import com.ryc.api.v2.common.exception.code.CommonErrorCode;
 import com.ryc.api.v2.common.exception.code.PermissionErrorCode;
+import com.ryc.api.v2.common.validator.request.annotation.NullOrNotBlank;
 import com.ryc.api.v2.role.domain.enums.Role;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -71,7 +72,7 @@ public class ApplicantHttpApi {
                 "FINAL_FAIL",
               })
           @RequestParam(value = "status", required = false)
-          @NotBlank(message = "지원자 상태는 공백일 수 없습니다.")
+          @NullOrNotBlank(message = "지원자 상태는 공백일 수 없습니다.")
           String status) {
     List<ApplicantGetResponse> response = applicantService.getApplicants(announcementId, status);
     return ResponseEntity.ok(response);

--- a/server/src/main/java/com/ryc/api/v2/application/presentation/dto/request/AnswerCreateRequest.java
+++ b/server/src/main/java/com/ryc/api/v2/application/presentation/dto/request/AnswerCreateRequest.java
@@ -3,8 +3,8 @@ package com.ryc.api.v2.application.presentation.dto.request;
 import java.util.List;
 
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import org.hibernate.validator.constraints.UUID;
 
@@ -16,7 +16,7 @@ import lombok.Builder;
 public record AnswerCreateRequest(
     @NotNull(message = "질문 아이디는 필수입니다.") @UUID(message = "질문 아이디는 UUID 포멧이어야 합니다.")
         String questionId,
-    @NullOrNotBlank @Max(value = 5000, message = "질문 답변값은 5000자를 초과할 수 없습니다.") String textAnswer,
+    @NullOrNotBlank @Size(max = 5000, message = "질문 답변값은 5000자를 초과할 수 없습니다.") String textAnswer,
     @NullOrNotBlank @UUID(message = "fileMetadataId는 UUID 포멧을 준수해야 합니다.") String fileMetadataId,
     List<@NotNull(message = "객관식 응답항목 원소는 null일 수 없습니다.") @Valid AnswerChoiceCreateRequest>
         answerChoices) {

--- a/server/src/main/java/com/ryc/api/v2/applicationForm/presentation/request/QuestionCreateRequest.java
+++ b/server/src/main/java/com/ryc/api/v2/applicationForm/presentation/request/QuestionCreateRequest.java
@@ -3,9 +3,9 @@ package com.ryc.api.v2.applicationForm.presentation.request;
 import java.util.List;
 
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import com.ryc.api.v2.applicationForm.domain.enums.QuestionType;
 
@@ -17,10 +17,10 @@ public record QuestionCreateRequest(
         QuestionType questionType,
     @Schema(description = "질문", example = "개발자의 성장 과정에서 중요하게 생각하는 가치를 서술해 주십시오.")
         @NotBlank(message = "질문은 빈 값일 수 없습니다.")
-        @Max(value = 500, message = "질문은 500자를 넘어갈 수 없습니다.")
+        @Size(max = 500, message = "질문은 500자를 넘어갈 수 없습니다.")
         String label,
     @Schema(description = "질문 설명", example = "자유롭게 서술해 주십시오 (500자 이하)")
-        @Max(value = 200, message = "질문 설명은 200자를 넘어갈 수 없습니다.")
+        @Size(max = 200, message = "질문 설명은 200자를 넘어갈 수 없습니다.")
         String description,
     @Schema(description = "필수 여부", example = "true")
         @NotNull(message = "질문 필수 여부는 null일 수 없습니다. true/false가 필요합니다.")

--- a/server/src/main/java/com/ryc/api/v2/applicationForm/presentation/request/QuestionOptionCreateRequest.java
+++ b/server/src/main/java/com/ryc/api/v2/applicationForm/presentation/request/QuestionOptionCreateRequest.java
@@ -1,12 +1,12 @@
 package com.ryc.api.v2.applicationForm.presentation.request;
 
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record QuestionOptionCreateRequest(
     @Schema(description = "질문 선지", example = "선지1")
         @NotBlank(message = "각 질문 선지는 빈값일 수 없습니다.")
-        @Max(value = 200, message = "각 질문 선지는 200자를 초과할 수 없습니다.")
+        @Size(max = 200, message = "각 질문 선지는 200자를 초과할 수 없습니다.")
         String option) {}

--- a/server/src/main/java/com/ryc/api/v2/applicationForm/presentation/request/QuestionOptionUpdateRequest.java
+++ b/server/src/main/java/com/ryc/api/v2/applicationForm/presentation/request/QuestionOptionUpdateRequest.java
@@ -1,7 +1,7 @@
 package com.ryc.api.v2.applicationForm.presentation.request;
 
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 import org.hibernate.validator.constraints.UUID;
 
@@ -16,5 +16,5 @@ public record QuestionOptionUpdateRequest(
         String id,
     @Schema(description = "질문 선지", example = "보기1")
         @NotBlank(message = "각 질문 선지는 빈값일 수 없습니다.")
-        @Max(value = 200, message = "각 질문 선지는 200자를 초과할 수 없습니다.")
+        @Size(max = 200, message = "각 질문 선지는 200자를 초과할 수 없습니다.")
         String option) {}

--- a/server/src/main/java/com/ryc/api/v2/applicationForm/presentation/request/QuestionUpdateRequest.java
+++ b/server/src/main/java/com/ryc/api/v2/applicationForm/presentation/request/QuestionUpdateRequest.java
@@ -3,9 +3,9 @@ package com.ryc.api.v2.applicationForm.presentation.request;
 import java.util.List;
 
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import org.hibernate.validator.constraints.UUID;
 
@@ -24,10 +24,10 @@ public record QuestionUpdateRequest(
         QuestionType questionType,
     @Schema(description = "질문", example = "개발자의 성장 과정에서 중요하게 생각하는 가치를 서술해 주십시오.")
         @NotBlank(message = "질문은 빈 값일 수 없습니다.")
-        @Max(value = 500, message = "질문은 500자를 넘어갈 수 없습니다.")
+        @Size(max = 500, message = "질문은 500자를 넘어갈 수 없습니다.")
         String label,
     @Schema(description = "질문 설명", example = "자유롭게 서술해 주십시오 (500자 이하)")
-        @Max(value = 200, message = "질문 설명은 200자를 넘어갈 수 없습니다.")
+        @Size(max = 200, message = "질문 설명은 200자를 넘어갈 수 없습니다.")
         String description,
     @Schema(description = "필수 여부", example = "true")
         @NotNull(message = "질문 필수 여부는 null일 수 없습니다. true/false가 필요합니다.")

--- a/server/src/main/java/com/ryc/api/v2/club/presentation/dto/request/ClubCreateRequest.java
+++ b/server/src/main/java/com/ryc/api/v2/club/presentation/dto/request/ClubCreateRequest.java
@@ -1,8 +1,7 @@
 package com.ryc.api.v2.club.presentation.dto.request;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -11,8 +10,7 @@ import lombok.Builder;
 public record ClubCreateRequest(
     @Schema(description = "동아리 이름")
         @NotBlank(message = "동아리 이름은 비워둘 수 없습니다.")
-        @Min(value = 2, message = "동아리 이름은 2자 이상이어야 합니다.")
-        @Max(value = 50, message = "동아리 이름은 50자 이하여야 합니다.")
+        @Size(min = 2, max = 50, message = "동아리 이름은 2자 이상, 50자 이하여야 합니다.")
         String name,
     @Schema(
             description = "카테고리",

--- a/server/src/main/java/com/ryc/api/v2/club/presentation/dto/request/ClubSummaryRequest.java
+++ b/server/src/main/java/com/ryc/api/v2/club/presentation/dto/request/ClubSummaryRequest.java
@@ -1,7 +1,7 @@
 package com.ryc.api.v2.club.presentation.dto.request;
 
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 import org.hibernate.validator.constraints.UUID;
 
@@ -14,9 +14,9 @@ public record ClubSummaryRequest(
         String id,
     @Schema(description = "동아리 요약 제목 값")
         @NotBlank(message = "동아리 요약 제목 값은 비워둘 수 없습니다.")
-        @Max(value = 20, message = "동아리 요약 제목은 20자를 초과할 수 없습니다.")
+        @Size(max = 20, message = "동아리 요약 제목은 20자를 초과할 수 없습니다.")
         String title,
     @Schema(description = "동아리 요약 본문 값")
         @NotBlank(message = "동아리 요약 본문 값은 비워둘 수 없습니다.")
-        @Max(value = 50, message = "동아리 요약 제목은 50자를 초과할 수 없습니다.")
+        @Size(max = 50, message = "동아리 요약 제목은 50자를 초과할 수 없습니다.")
         String content) {}

--- a/server/src/main/java/com/ryc/api/v2/club/presentation/dto/request/ClubTagRequest.java
+++ b/server/src/main/java/com/ryc/api/v2/club/presentation/dto/request/ClubTagRequest.java
@@ -1,7 +1,7 @@
 package com.ryc.api.v2.club.presentation.dto.request;
 
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 import org.hibernate.validator.constraints.UUID;
 
@@ -14,5 +14,5 @@ public record ClubTagRequest(
         String id,
     @Schema(description = "동아리 태그")
         @NotBlank(message = "동아리 태그 이름은 비워둘 수 없습니다.")
-        @Max(value = 30, message = "동아리 태그 이름은 30자를 초과할 수 없습니다.")
+        @Size(max = 30, message = "동아리 태그 이름은 30자를 초과할 수 없습니다.")
         String name) {}

--- a/server/src/main/java/com/ryc/api/v2/club/presentation/dto/request/ClubUpdateRequest.java
+++ b/server/src/main/java/com/ryc/api/v2/club/presentation/dto/request/ClubUpdateRequest.java
@@ -3,9 +3,8 @@ package com.ryc.api.v2.club.presentation.dto.request;
 import java.util.List;
 
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 import org.hibernate.validator.constraints.UUID;
 
@@ -16,15 +15,13 @@ import lombok.Builder;
 public record ClubUpdateRequest(
     @Schema(description = "동아리 이름")
         @NotBlank(message = "동아리 이름은 비워둘 수 없습니다. 수정되지 않았다면 기존의 값을 입력해주세요.")
-        @Min(value = 2, message = "동아리 이름은 2자 이상이어야 합니다.")
-        @Max(value = 50, message = "동아리 이름은 50자 이하여야 합니다.")
+        @Size(min = 2, max = 50, message = "동아리 이름은 2자 이상, 50자 이하여야 합니다.")
         String name,
     @Schema(description = "동아리 간단 설명")
         @NotBlank(message = "동아리 간단 설명(shortDescription)은 비워둘 수 없습니다. 수정되지 않았다면 기존의 값을 입력해주세요.")
-        @Max(value = 200, message = "동아리 간단 설명(shortDescription)은 200자를 초과할 수 없습니다.")
+        @Size(max = 200, message = "동아리 간단 설명(shortDescription)은 200자를 초과할 수 없습니다.")
         String shortDescription,
-    @Schema(description = "동아리 상세 설명")
-        @Max(value = 5000, message = "동아리 상세설명은 최대 5000자까지 입력 가능합니다.")
+    @Schema(description = "동아리 상세 설명") @Size(max = 5000, message = "동아리 상세설명은 최대 5000자까지 입력 가능합니다.")
         String detailDescription,
     @Schema(description = "동아리 대표 이미지") @UUID(message = "동아리 대표이미지 메타데이터 ID는 UUID를 준수해야 합니다.")
         String representativeImage,

--- a/server/src/main/java/com/ryc/api/v2/email/presentation/dto/request/EmailSendRequest.java
+++ b/server/src/main/java/com/ryc/api/v2/email/presentation/dto/request/EmailSendRequest.java
@@ -2,9 +2,9 @@ package com.ryc.api.v2.email.presentation.dto.request;
 
 import java.util.List;
 
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import com.ryc.api.v2.common.validator.request.annotation.Email;
 
@@ -17,11 +17,11 @@ public record EmailSendRequest(
         List<@NotBlank(message = "수신자 이메일은 빈 값일 수 없습니다.") @Email String> recipients,
     @Schema(description = "메일 제목")
         @NotBlank(message = "메일 제목은 비워둘 수 없습니다.")
-        @Max(value = 255, message = "메일 제목은 255자를 초과할 수 없습니다.")
+        @Size(max = 255, message = "메일 제목은 255자를 초과할 수 없습니다.")
         String subject,
     @Schema(description = "메일 본문")
         @NotBlank(message = "메일 본문은 비워둘 수 없습니다.")
-        @Max(value = 10000, message = "메일 본문은 10000자를 초과할 수 없습니다.")
+        @Size(max = 10000, message = "메일 본문은 10000자를 초과할 수 없습니다.")
         String content) {
 
   @Override

--- a/server/src/main/java/com/ryc/api/v2/evaluation/presentation/dto/request/ApplicationEvaluationRequest.java
+++ b/server/src/main/java/com/ryc/api/v2/evaluation/presentation/dto/request/ApplicationEvaluationRequest.java
@@ -14,6 +14,6 @@ public record ApplicationEvaluationRequest(
         @DecimalMin(value = "0.0", inclusive = true, message = "점수는 최소 0.0 이상 이어야 합니다.")
         @DecimalMax(value = "5.0", inclusive = true, message = "점수는 최대 5.0 이하 이어야 합니다.")
         BigDecimal score,
-    @NotBlank(message = "평가는 빈값일 수 없습니다.") @Max(value = 500, message = "평가는 500자를 초과할 수 없습니다.")
+    @NotBlank(message = "평가는 빈값일 수 없습니다.") @Size(max = 500, message = "평가는 500자를 초과할 수 없습니다.")
         String comment)
     implements EvaluationRequest {}

--- a/server/src/main/java/com/ryc/api/v2/evaluation/presentation/dto/request/EvaluationUpdateRequest.java
+++ b/server/src/main/java/com/ryc/api/v2/evaluation/presentation/dto/request/EvaluationUpdateRequest.java
@@ -15,5 +15,5 @@ public record EvaluationUpdateRequest(
         BigDecimal score,
     @Schema(description = "수정된 코멘트", example = "훌륭하십니다")
         @NotBlank(message = "평가는 빈값일 수 없습니다.")
-        @Max(value = 500, message = "평가는 500자를 초과할 수 없습니다.")
+        @Size(max = 500, message = "평가는 500자를 초과할 수 없습니다.")
         String comment) {}

--- a/server/src/main/java/com/ryc/api/v2/evaluation/presentation/dto/request/InterviewEvaluationRequest.java
+++ b/server/src/main/java/com/ryc/api/v2/evaluation/presentation/dto/request/InterviewEvaluationRequest.java
@@ -14,6 +14,6 @@ public record InterviewEvaluationRequest(
         @DecimalMin(value = "0.0", inclusive = true, message = "점수는 최소 0.0 이상 이어야 합니다.")
         @DecimalMax(value = "5.0", inclusive = true, message = "점수는 최대 5.0 이하 이어야 합니다.")
         BigDecimal score,
-    @NotBlank(message = "평가는 빈값일 수 없습니다.") @Max(value = 500, message = "평가는 500자를 초과할 수 없습니다.")
+    @NotBlank(message = "평가는 빈값일 수 없습니다.") @Size(max = 500, message = "평가는 500자를 초과할 수 없습니다.")
         String comment)
     implements EvaluationRequest {}

--- a/server/src/main/java/com/ryc/api/v2/file/presentation/dto/request/UploadUrlRequest.java
+++ b/server/src/main/java/com/ryc/api/v2/file/presentation/dto/request/UploadUrlRequest.java
@@ -1,16 +1,12 @@
 package com.ryc.api.v2.file.presentation.dto.request;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record UploadUrlRequest(
-    @NotBlank
-        @Min(value = 1, message = "파일 이름은 1자 이상이어야 합니다.")
-        @Max(value = 255, message = "파일 이름은 255자 이하이어야 합니다.")
-        String fileName,
+    @NotBlank @Size(min = 1, max = 255, message = "파일 이름은 1자 이상, 255자 이하이어야 합니다.") String fileName,
     @Schema(
             description = "파일 타입",
             example = "CLUB_PROFILE",

--- a/server/src/main/java/com/ryc/api/v2/interview/presentation/dto/request/NumberOfPeopleByInterviewDateRequest.java
+++ b/server/src/main/java/com/ryc/api/v2/interview/presentation/dto/request/NumberOfPeopleByInterviewDateRequest.java
@@ -18,7 +18,7 @@ public record NumberOfPeopleByInterviewDateRequest(
         LocalDateTime start,
     @Schema(description = "면접 당 진행 시간(분)")
         @NotNull(message = "면접 당 진행 시간은 null일 수 없습니다.")
-        @Min(value = 1, message = "면접 당 진행 시간은 0 이하일 수 없습니다.")
+        @Min(value = 1, message = "면접 당 진행 시간은 0분 이하일 수 없습니다.")
         Integer interviewDuration,
     @Schema(description = "인원 수")
         @NotNull(message = "면접 날짜별 인원 수는 null일 수 없습니다.")


### PR DESCRIPTION
## 📌 관련 이슈
closed #455 

## 🛠️ 작업 내용
- [x] 공고 지원자 리스트 조회시, 지원자 상태값 null값 허용
- [x] 문자열 길이 검증 어노테이션 오류 수정(@Size)

## ⏳ 작업 시간
추정 시간:   1시간
실제 시간:   15분
