### PR TITLE
[FE] Error UI 설정 및 버그 수정

### DIFF
--- a/monorepo/apps/admin/src/api/hooks/fileMutations.ts
+++ b/monorepo/apps/admin/src/api/hooks/fileMutations.ts
@@ -1,17 +1,24 @@
 import { HttpError } from '@api/common/httpError';
 import { postIdAndGetFileDownloadUrl } from '@api/domain/file/file';
+import type { ErrorWithStatusCode } from '@pages/ErrorFallbackPage/types';
 import { useMutation } from '@tanstack/react-query';
+import { getErrorMessage } from '@utils/getErrorMessage';
+
+import { useToast } from '@ssoc/ui';
 
 export const fileMutations = {
     usePostIdAndGetFileDownloadUrl: () => {
+        const { toast } = useToast();
         return useMutation({
             mutationFn: postIdAndGetFileDownloadUrl,
             onSuccess: (data) => {},
             onError: (error) => {
-                if (error instanceof HttpError && error.statusCode === 500) {
-                    return;
-                }
-                throw error;
+                // 500에러까지 한번에 처리 (dialog 불가)
+                toast(getErrorMessage(error as ErrorWithStatusCode), {
+                    toastTheme: 'colored',
+                    type: 'error',
+                });
+                // throw error
             },
         });
     },

--- a/monorepo/apps/admin/src/api/hooks/useEmailMutations.ts
+++ b/monorepo/apps/admin/src/api/hooks/useEmailMutations.ts
@@ -1,10 +1,10 @@
 import { postInterviewEmail, postPlainEmail } from '@api/domain';
 import type { Email, InterviewEmail } from '@api/domain/email/types';
+import type { ErrorWithStatusCode } from '@pages/ErrorFallbackPage/types';
 import { useMutation } from '@tanstack/react-query';
+import { getErrorMessage } from '@utils/getErrorMessage';
 
 import { useToast } from '@ssoc/ui';
-
-import { HttpError } from '../common/httpError';
 
 type EmailMutationParams<T> = {
     announcementId: string;
@@ -27,13 +27,13 @@ const useEmailMutation = <T>(
                 toastTheme: 'colored',
             });
         },
-        onError: (error) => {
+        onError: (error: ErrorWithStatusCode) => {
             onClose(false);
-            // 500 에러인 경우 전역 처리에 위임
-            if (error instanceof HttpError && error.statusCode === 500) {
-                return;
+            if (error.response?.errors[0].message || error.message) {
+                toast(getErrorMessage(error), { type: 'error', toastTheme: 'colored' });
+            } else {
+                toast('이메일 전송에 실패했어요.', { type: 'error', toastTheme: 'colored' });
             }
-            toast('이메일 전송에 실패했어요.', { type: 'error', toastTheme: 'colored' });
         },
     });
 };

--- a/monorepo/apps/admin/src/components/DatePicker/DatePicker.tsx
+++ b/monorepo/apps/admin/src/components/DatePicker/DatePicker.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import CalenarIcon from '@ssoc/assets/images/calendar.svg';
 import { Button, Calendar, Dropdown, Text } from '@ssoc/ui';
@@ -31,6 +31,8 @@ function DatePicker({
     alwaysOpenLabel = '상시 모집',
     alwaysOpenSentinel = DEFAULT_ALWAYS_OPEN_SENTINEL,
 }: DatePickerProps) {
+    const [dropdownOpen, setDropdownOpen] = useState<boolean>(false);
+
     const formatLabel = () => {
         if (isAlwaysOpen(selectedDate, alwaysOpenSentinel)) {
             return alwaysOpenLabel;
@@ -45,10 +47,16 @@ function DatePicker({
 
     const handleAlwaysOpenClick = () => {
         onChange?.([alwaysOpenSentinel, alwaysOpenSentinel]);
+        setDropdownOpen(false);
     };
 
+    useEffect(() => {
+        if (selectedDate.length === 2 && mode === 'range') setDropdownOpen(false);
+        else if (selectedDate.length === 1 && mode === 'single') setDropdownOpen(false);
+    }, [selectedDate]);
+
     return (
-        <Dropdown sx={s_dropdown}>
+        <Dropdown open={dropdownOpen} onOpenChange={setDropdownOpen} sx={s_dropdown}>
             <Dropdown.Trigger asChild>
                 <Button sx={s_triggerButton(selectedDate)} variant="outlined">
                     <div css={s_labelWithIcon}>

--- a/monorepo/apps/admin/src/components/ErrorDialog/ErrorDialog.tsx
+++ b/monorepo/apps/admin/src/components/ErrorDialog/ErrorDialog.tsx
@@ -1,5 +1,5 @@
 import { DEFAULT_DESCRIPTION, ERROR_500_DESCRIPTION } from '@constants/errorText';
-import { getErrorMessage } from '@utils/getErrorMessage';
+import { getErrorPlainMessageByErrorStatusCode } from '@utils/getErrorMessage';
 import React from 'react';
 
 import { useRouter } from '@ssoc/hooks';
@@ -8,13 +8,19 @@ import { Button, Dialog, Text } from '@ssoc/ui';
 import { s_textWrapper } from './ErrorDialog.style';
 import type { ErrorDialogProps } from './type';
 
-function ErrorDialog({ open, handleClose, error, content, subContent }: ErrorDialogProps) {
+function ErrorDialog({
+    open,
+    handleClose,
+    errorStatusCode,
+    content,
+    subContent,
+}: ErrorDialogProps) {
     // prop destruction
     // lib hooks
     const { goTo } = useRouter();
 
     // initial values
-    let message = getErrorMessage(error);
+    let message = getErrorPlainMessageByErrorStatusCode(errorStatusCode);
 
     // state, ref, querystring hooks
     // form hooks
@@ -40,13 +46,13 @@ function ErrorDialog({ open, handleClose, error, content, subContent }: ErrorDia
                     <Text type="subCaptionRegular" textAlign="center" sx={s_textWrapper}>
                         {subContent
                             ? subContent
-                            : error.statusCode === 500
+                            : errorStatusCode === 500
                               ? ERROR_500_DESCRIPTION
                               : DEFAULT_DESCRIPTION}
                     </Text>
                 </Dialog.Content>
                 <Dialog.Action position="center">
-                    {error.statusCode === 500 ? (
+                    {errorStatusCode === 500 ? (
                         <div>
                             <Button
                                 onClick={() => {
@@ -57,7 +63,7 @@ function ErrorDialog({ open, handleClose, error, content, subContent }: ErrorDia
                                 오류 신고
                             </Button>
                         </div>
-                    ) : error.statusCode === 401 ? (
+                    ) : errorStatusCode === 401 ? (
                         <div>
                             <Button
                                 onClick={() => {

--- a/monorepo/apps/admin/src/components/ErrorDialog/ErrorDialog.tsx
+++ b/monorepo/apps/admin/src/components/ErrorDialog/ErrorDialog.tsx
@@ -1,13 +1,5 @@
-import {
-    DEFAULT_DESCRIPTION,
-    ERROR_500_DESCRIPTION,
-    ERROR_CODE_400,
-    ERROR_CODE_401,
-    ERROR_CODE_403,
-    ERROR_CODE_404_DATA,
-    ERROR_CODE_500,
-    ERROR_DEFAULT,
-} from '@constants/errorText';
+import { DEFAULT_DESCRIPTION, ERROR_500_DESCRIPTION } from '@constants/errorText';
+import { getErrorMessage } from '@utils/getErrorMessage';
 import React from 'react';
 
 import { useRouter } from '@ssoc/hooks';
@@ -16,45 +8,18 @@ import { Button, Dialog, Text } from '@ssoc/ui';
 import { s_textWrapper } from './ErrorDialog.style';
 import type { ErrorDialogProps } from './type';
 
-function ErrorDialog({
-    open,
-    handleClose,
-    errorStatusCode,
-    content,
-    subContent,
-}: ErrorDialogProps) {
+function ErrorDialog({ open, handleClose, error, content, subContent }: ErrorDialogProps) {
     // prop destruction
     // lib hooks
     const { goTo } = useRouter();
 
     // initial values
-    let message = ERROR_DEFAULT;
+    let message = getErrorMessage(error);
 
     // state, ref, querystring hooks
     // form hooks
     // query hooks
     // calculated values
-    switch (errorStatusCode) {
-        case 500:
-            message = ERROR_CODE_500;
-            break;
-        case 404:
-            message = ERROR_CODE_404_DATA;
-            break;
-        case 403:
-            message = ERROR_CODE_403;
-            break;
-        case 401:
-            message = ERROR_CODE_401;
-            break;
-        case 400:
-            message = ERROR_CODE_400;
-            break;
-        default:
-            message = ERROR_DEFAULT;
-            break;
-    }
-
     if (content) message = content;
 
     // handlers
@@ -75,13 +40,13 @@ function ErrorDialog({
                     <Text type="subCaptionRegular" textAlign="center" sx={s_textWrapper}>
                         {subContent
                             ? subContent
-                            : errorStatusCode === 500
+                            : error.statusCode === 500
                               ? ERROR_500_DESCRIPTION
                               : DEFAULT_DESCRIPTION}
                     </Text>
                 </Dialog.Content>
                 <Dialog.Action position="center">
-                    {errorStatusCode === 500 ? (
+                    {error.statusCode === 500 ? (
                         <div>
                             <Button
                                 onClick={() => {
@@ -92,7 +57,7 @@ function ErrorDialog({
                                 오류 신고
                             </Button>
                         </div>
-                    ) : errorStatusCode === 401 ? (
+                    ) : error.statusCode === 401 ? (
                         <div>
                             <Button
                                 onClick={() => {

--- a/monorepo/apps/admin/src/components/ErrorDialog/type.ts
+++ b/monorepo/apps/admin/src/components/ErrorDialog/type.ts
@@ -1,7 +1,9 @@
+import type { ErrorWithStatusCode } from '@pages/ErrorFallbackPage/types';
+
 export interface ErrorDialogProps {
     open: boolean;
     handleClose: () => void;
-    errorStatusCode?: number;
+    error: ErrorWithStatusCode;
     content?: string;
     subContent?: string;
 }

--- a/monorepo/apps/admin/src/components/ErrorDialog/type.ts
+++ b/monorepo/apps/admin/src/components/ErrorDialog/type.ts
@@ -1,9 +1,7 @@
-import type { ErrorWithStatusCode } from '@pages/ErrorFallbackPage/types';
-
 export interface ErrorDialogProps {
     open: boolean;
     handleClose: () => void;
-    error: ErrorWithStatusCode;
+    errorStatusCode: number;
     content?: string;
     subContent?: string;
 }

--- a/monorepo/apps/admin/src/components/MainCardEditDialog/MainCardEditDialog.tsx
+++ b/monorepo/apps/admin/src/components/MainCardEditDialog/MainCardEditDialog.tsx
@@ -4,6 +4,8 @@ import ssoc from '@assets/images/ssoc.png';
 import { HashTagInput } from '@components';
 import type { Tag } from '@components/HashTagInput/types';
 import { useUpdateClub } from '@hooks/useUpdateClub';
+import type { ErrorWithStatusCode } from '@pages/ErrorFallbackPage/types';
+import { getErrorMessage } from '@utils/getErrorMessage';
 import { useState } from 'react';
 
 import { Input, Text, useToast } from '@ssoc/ui';
@@ -63,11 +65,17 @@ function MainCardEditDialog({
                 toastTheme: 'white',
                 type: 'success',
             });
-        } catch (error) {
-            toast('동아리 정보 수정에 실패했습니다. 다시 시도해주세요.', {
-                toastTheme: 'white',
-                type: 'error',
-            });
+        } catch (err) {
+            const error = err as ErrorWithStatusCode;
+            // Dialog에서는 500 에러 토스트로 처리
+            if (error.response?.errors[0].message || error.message) {
+                toast(getErrorMessage(error), { type: 'error', toastTheme: 'colored' });
+            } else {
+                toast(`동아리 정보 수정에 실패했습니다. 다시 시도해주세요.`, {
+                    type: 'error',
+                    toastTheme: 'colored',
+                });
+            }
             console.error(error);
         }
         onClose();

--- a/monorepo/apps/admin/src/hooks/components/useEvaluation.tsx
+++ b/monorepo/apps/admin/src/hooks/components/useEvaluation.tsx
@@ -1,12 +1,13 @@
 import type { EvaluationType } from '@api/domain/evaluation/types';
 import { useEvaluationMutations } from '@api/hooks/useEvaluationMutations';
+import type { ErrorWithStatusCode } from '@pages/ErrorFallbackPage/types';
 
 function useEvaluation(
     type: EvaluationType,
     selectedApplicantId: string,
     getEvaluationActionCallbacks: (status: string) => {
         onSuccess: () => void;
-        onError: () => void;
+        onError: (error: ErrorWithStatusCode) => void;
     },
 ) {
     const { mutate: postComment } = useEvaluationMutations.usePostPersonalEvaluation();
@@ -22,7 +23,12 @@ function useEvaluation(
     ) => {
         postComment(
             { applicantId, score, comment, clubId, type: type },
-            getEvaluationActionCallbacks('등록'),
+            {
+                onSuccess: getEvaluationActionCallbacks('등록').onSuccess,
+                onError: (error) => {
+                    getEvaluationActionCallbacks('등록').onError(error as ErrorWithStatusCode);
+                },
+            },
         );
     };
 
@@ -34,12 +40,25 @@ function useEvaluation(
     ) => {
         updateComment(
             { evaluationId, score, comment, clubId, type: type },
-            getEvaluationActionCallbacks('수정'),
+            {
+                onSuccess: getEvaluationActionCallbacks('수정').onSuccess,
+                onError: (error) => {
+                    getEvaluationActionCallbacks('수정').onError(error as ErrorWithStatusCode);
+                },
+            },
         );
     };
 
     const handleDeleteComment = (evaluationId: string, clubId: string) => {
-        deleteComment({ evaluationId, clubId, type: type }, getEvaluationActionCallbacks('삭제'));
+        deleteComment(
+            { evaluationId, clubId, type: type },
+            {
+                onSuccess: getEvaluationActionCallbacks('삭제').onSuccess,
+                onError: (error) => {
+                    getEvaluationActionCallbacks('삭제').onError(error as ErrorWithStatusCode);
+                },
+            },
+        );
     };
 
     return {

--- a/monorepo/apps/admin/src/hooks/useLogin.tsx
+++ b/monorepo/apps/admin/src/hooks/useLogin.tsx
@@ -12,7 +12,7 @@ interface UseLoginOptions {
     redirectPath?: string;
 }
 
-function useLogin(options?: UseLoginOptions) {
+function useLogin(onErrorDialogOpen: (open: boolean) => void, options?: UseLoginOptions) {
     const setAccessToken = useAuthStore((state) => state.setAccessToken);
     const { removeHistoryAndGo } = useRouter();
     const { toast } = useToast();
@@ -25,6 +25,7 @@ function useLogin(options?: UseLoginOptions) {
         },
         onError: (error) => {
             if (error instanceof HttpError && error.statusCode === 500) {
+                onErrorDialogOpen(true);
                 return;
             }
             toast.error('로그인에 실패했습니다. 이메일 또는 비밀번호를 확인해주세요.', {

--- a/monorepo/apps/admin/src/hooks/useQuestion.tsx
+++ b/monorepo/apps/admin/src/hooks/useQuestion.tsx
@@ -1,5 +1,5 @@
 import type { QuestionProps, QuestionType } from '@components/QuestionForm/types';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useId, useState } from 'react';
 
 const DEFAULT_OPTIONS = [
     { id: 'opt1', text: '' },
@@ -11,9 +11,11 @@ export const useQuestion = () => {
 
     const [applicationQuestions, setApplicationQuestions] = useState<QuestionProps[]>([]);
 
+    const newId = crypto.randomUUID();
+
     const addQuestion = () => {
         const newQuestion: QuestionProps = {
-            id: `q${Date.now()}`,
+            id: newId,
             type: 'short',
             title: '',
             required: false,
@@ -23,7 +25,7 @@ export const useQuestion = () => {
 
     const addApplicationQuestion = () => {
         const newQuestion: QuestionProps = {
-            id: `q${Date.now()}`,
+            id: newId,
             type: 'long',
             title: '',
             subContent: '',

--- a/monorepo/apps/admin/src/hooks/useRegister.tsx
+++ b/monorepo/apps/admin/src/hooks/useRegister.tsx
@@ -7,7 +7,7 @@ import { useToast } from '@ssoc/ui';
 
 import { HttpError } from '../api/common/httpError';
 
-function useRegister() {
+function useRegister(onErrorDialogOpen: (open: boolean) => void) {
     const navigate = useNavigate();
     const { toast } = useToast();
 
@@ -17,8 +17,8 @@ function useRegister() {
             navigate('/login', { replace: true });
         },
         onError: (error) => {
-            // 500 에러인 경우 전역 처리에 위임
             if (error instanceof HttpError && error.statusCode === 500) {
+                onErrorDialogOpen(true);
                 return;
             }
             toast.error('회원가입에 실패했습니다.', {

--- a/monorepo/apps/admin/src/hooks/useUpdateClub.ts
+++ b/monorepo/apps/admin/src/hooks/useUpdateClub.ts
@@ -14,13 +14,6 @@ const useUpdateClub = () => {
             queryClient.setQueryData(clubKeys.detail(id), response);
             return response;
         },
-        onError: (error) => {
-            // 500 에러인 경우 전역 처리에 위임 (콘솔 로깅은 제외)
-            if (error instanceof HttpError && error.statusCode === 500) {
-                return;
-            }
-            console.error(error);
-        },
     });
 };
 

--- a/monorepo/apps/admin/src/index.tsx
+++ b/monorepo/apps/admin/src/index.tsx
@@ -32,14 +32,14 @@ function handleGlobalError(error: unknown) {
 const queryClient = new QueryClient({
     queryCache: new QueryCache({
         onError: (error) => {
-            handleGlobalError(error);
+            throw error;
         },
     }),
-    mutationCache: new MutationCache({
-        onError: (error) => {
-            handleGlobalError(error);
-        },
-    }),
+    // mutationCache: new MutationCache({
+    //     onError: (error) => {
+    //         handleGlobalError(error);
+    //     },
+    // }),
 });
 
 function ToastManager() {

--- a/monorepo/apps/admin/src/pages/AnnouncementPage/AnnouncementPage.tsx
+++ b/monorepo/apps/admin/src/pages/AnnouncementPage/AnnouncementPage.tsx
@@ -26,9 +26,10 @@ function AnnouncementPage() {
     const { clubId, announcementId } = useParams();
 
     const { data: club } = useSuspenseQuery(myClubQueries.detail(clubId ?? ''));
-    const { data: detailClub } = useQuery<DetailAnnouncement>(
-        announcementQueries.detail(announcementId ?? ''),
-    );
+    const { data: detailClub } = useQuery<DetailAnnouncement>({
+        ...announcementQueries.detail(announcementId ?? ''),
+        throwOnError: true,
+    });
 
     const imageUrls = useMemo(
         () => (detailClub?.images ?? []).map((image) => image.url),

--- a/monorepo/apps/admin/src/pages/ApplicantSchedulePage/ApplicantSchedulePage.tsx
+++ b/monorepo/apps/admin/src/pages/ApplicantSchedulePage/ApplicantSchedulePage.tsx
@@ -7,7 +7,7 @@ import type { StepApplicant } from '@api/domain/step/types';
 import { useInterviewMutations } from '@api/hooks';
 import { interviewQueries } from '@api/queryFactory';
 import Alert from '@assets/images/alert.svg';
-import { ApplicantList, ComponentMover, InterviewSlotDropdown } from '@components';
+import { ApplicantList, ComponentMover, ErrorDialog, InterviewSlotDropdown } from '@components';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import type { Dispatch, SetStateAction } from 'react';
@@ -50,6 +50,8 @@ function ApplicantSchedulePage() {
     const [selectedStandardInterviewLabel, setSelectedStandardInterviewLabel] =
         useState<SelectedLabel>({ label: '면접 일정 없음', interviewSlotId: null });
 
+    const [errorDialogOpen, setErrorDialogOpen] = useState<boolean>(false);
+
     // form hooks
     // query hooks
     const { data: interviewSlots = [] } = useSuspenseQuery(
@@ -71,9 +73,11 @@ function ApplicantSchedulePage() {
 
     const { mutate: updateIntervieweeList } = useInterviewMutations.useUpdateInterviewReservation(
         announcementId!,
+        setErrorDialogOpen,
     );
     const { mutate: deleteReservation } = useInterviewMutations.useDeleteReservation(
         announcementId!,
+        setErrorDialogOpen,
     );
 
     // calculated values
@@ -344,6 +348,11 @@ function ApplicantSchedulePage() {
                     />
                 </div>
             </div>
+            <ErrorDialog
+                open={errorDialogOpen}
+                handleClose={() => setErrorDialogOpen(false)}
+                errorStatusCode={500}
+            />
         </div>
     );
 }

--- a/monorepo/apps/admin/src/pages/AuthPage/LoginPage/LoginPage.tsx
+++ b/monorepo/apps/admin/src/pages/AuthPage/LoginPage/LoginPage.tsx
@@ -1,3 +1,4 @@
+import { ErrorDialog } from '@components';
 import { useLogin } from '@hooks/useLogin';
 import type { FormEvent } from 'react';
 import React, { useCallback, useEffect, useState } from 'react';
@@ -30,6 +31,7 @@ function LoginPage() {
     // state, ref, querystring hooks
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
+    const [errorDialogOpen, setErrorDialogOpen] = useState<boolean>(false);
 
     // form hooks
     // query hooks
@@ -37,7 +39,7 @@ function LoginPage() {
         mutate: login,
         isPending,
         error,
-    } = useLogin({
+    } = useLogin(setErrorDialogOpen, {
         redirectPath: state?.from,
     });
 
@@ -93,6 +95,11 @@ function LoginPage() {
                         계정이 없으신가요?
                     </Button>
                 </div>
+                <ErrorDialog
+                    open={errorDialogOpen}
+                    handleClose={() => setErrorDialogOpen(false)}
+                    errorStatusCode={500}
+                />
             </div>
         </form>
     );

--- a/monorepo/apps/admin/src/pages/AuthPage/RegisterPage/RegisterPage.tsx
+++ b/monorepo/apps/admin/src/pages/AuthPage/RegisterPage/RegisterPage.tsx
@@ -38,7 +38,7 @@ function RegisterPage() {
         data: isDuplicateEmail,
         isLoading: emailLoading,
         refetch: refetchEmail,
-    } = useQuery(userQueries.checkDuplicateEmail(email));
+    } = useQuery({ ...userQueries.checkDuplicateEmail(email), throwOnError: true });
 
     // calculated values
     // handlers

--- a/monorepo/apps/admin/src/pages/AuthPage/RegisterPage/RegisterPage.tsx
+++ b/monorepo/apps/admin/src/pages/AuthPage/RegisterPage/RegisterPage.tsx
@@ -1,4 +1,5 @@
 import { userQueries } from '@api/queryFactory';
+import { ErrorDialog } from '@components';
 import { css } from '@emotion/react';
 import { useRegister } from '@hooks/useRegister';
 import { useQuery } from '@tanstack/react-query';
@@ -30,10 +31,11 @@ function RegisterPage() {
     const [password, setPassword] = useState('');
     const [passwordConfirm, setPasswordConfirm] = useState('');
     const [isPossible, setIsPossible] = useState(false);
+    const [errorDialogOpen, setErrorDialogOpen] = useState<boolean>(false);
 
     // form hooks
     // query hooks
-    const { mutate: register, isPending, error } = useRegister();
+    const { mutate: register, isPending, error } = useRegister(setErrorDialogOpen);
     const {
         data: isDuplicateEmail,
         isLoading: emailLoading,
@@ -180,6 +182,11 @@ function RegisterPage() {
                         이미 계정이 있으신가요?
                     </Button>
                 </div>
+                <ErrorDialog
+                    open={errorDialogOpen}
+                    handleClose={() => setErrorDialogOpen(false)}
+                    errorStatusCode={500}
+                />
             </div>
         </form>
     );

--- a/monorepo/apps/admin/src/pages/ClubCreatePage/ClubCreatePage.tsx
+++ b/monorepo/apps/admin/src/pages/ClubCreatePage/ClubCreatePage.tsx
@@ -89,12 +89,19 @@ function ClubCreatePage() {
             return typeof fileMetadataId?.[0]?.fileMetadataId === 'string'
                 ? fileMetadataId[0].fileMetadataId
                 : '';
-        } catch (error) {
-            toast.error('이미지 업로드에 실패했어요.', {
-                type: 'error',
-                toastTheme: 'white',
-            });
-            throw error;
+        } catch (err) {
+            const error = err as ErrorWithStatusCode;
+            if (error.statusCode === 500) {
+                setErrorDialogOpen(true);
+            } else if (error.response?.errors[0].message || error.message) {
+                toast(getErrorMessage(error), { type: 'error', toastTheme: 'colored' });
+            } else {
+                toast(`이미지 업로드에 실패했어요.`, {
+                    type: 'error',
+                    toastTheme: 'white',
+                });
+            }
+            // throw error;
         }
     };
 
@@ -157,11 +164,6 @@ function ClubCreatePage() {
             resetForm();
             removeHistoryAndGo(`/clubs/${result.clubId}`);
         } catch (err) {
-            // if (error instanceof Error) {
-            //     toast(error.message, {
-            //         type: 'error',
-            //     });
-            // }
             const error = err as ErrorWithStatusCode;
             if (error.statusCode === 500) {
                 setErrorDialogOpen(true);

--- a/monorepo/apps/admin/src/pages/ClubEditPage/ClubEditPage.tsx
+++ b/monorepo/apps/admin/src/pages/ClubEditPage/ClubEditPage.tsx
@@ -217,12 +217,19 @@ function ClubEditPage() {
             return typeof fileMetadataId?.[0]?.fileMetadataId === 'string'
                 ? fileMetadataId[0].fileMetadataId
                 : '';
-        } catch (error) {
-            toast.error('이미지 업로드에 실패했어요.', {
-                type: 'error',
-                toastTheme: 'white',
-            });
-            throw error;
+        } catch (err) {
+            const error = err as ErrorWithStatusCode;
+            if (error.statusCode === 500) {
+                setErrorDialogOpen(true);
+            } else if (error.response?.errors[0].message || error.message) {
+                toast(getErrorMessage(error), { type: 'error', toastTheme: 'colored' });
+            } else {
+                toast(`이미지 업로드에 실패했어요.`, {
+                    type: 'error',
+                    toastTheme: 'white',
+                });
+            }
+            // throw error;
         }
     };
 
@@ -265,18 +272,13 @@ function ClubEditPage() {
                 type: 'success',
             });
         } catch (err) {
-            // toast('업데이트에 실패했습니다. 다시 시도해주세요.', {
-            //     toastTheme: 'white',
-            //     type: 'error',
-            // });
-            // console.error(error);
             const error = err as ErrorWithStatusCode;
             if (error.statusCode === 500) {
                 setErrorDialogOpen(true);
             } else if (error.response?.errors[0].message || error.message) {
                 toast(getErrorMessage(error), { type: 'error', toastTheme: 'colored' });
             } else {
-                toast('오류로 인해 업데이트를 실패했어요.', {
+                toast('오류로 인해 업데이트에 실패했어요.', {
                     toastTheme: 'colored',
                     type: 'error',
                 });

--- a/monorepo/apps/admin/src/pages/ClubEditPage/ClubEditPage.tsx
+++ b/monorepo/apps/admin/src/pages/ClubEditPage/ClubEditPage.tsx
@@ -66,7 +66,7 @@ function ClubEditPage() {
 
     // form hooks
     // query hooks
-    const { data: club } = useQuery(myClubQueries.detail(clubId ?? ''));
+    const { data: club } = useQuery({ ...myClubQueries.detail(clubId ?? ''), throwOnError: true });
     const { mutateAsync: updateClub, isPending: isUpdateLoading } = useUpdateClub();
     const { uploadFiles, error } = useFileUpload(BASE_URL);
     const { handleContentChange } = useEditorImageUpload({ location: 'CLUB_EDITOR' });

--- a/monorepo/apps/admin/src/pages/ClubEditPage/ClubEditPage.tsx
+++ b/monorepo/apps/admin/src/pages/ClubEditPage/ClubEditPage.tsx
@@ -1,11 +1,13 @@
 import type { Club, UpdateClub } from '@api/domain/club/types';
 import { myClubQueries } from '@api/queryFactory';
 import ssoc from '@assets/images/ssoc.png';
-import { ClubBox, ImageRegister, MainCardEditDialog } from '@components';
+import { ClubBox, ErrorDialog, ImageRegister, MainCardEditDialog } from '@components';
 import { BASE_URL } from '@constants/api';
 import { useEditorImageUpload } from '@hooks/useEditorImageUpload';
 import { useUpdateClub } from '@hooks/useUpdateClub';
+import type { ErrorWithStatusCode } from '@pages/ErrorFallbackPage/types';
 import { useQuery } from '@tanstack/react-query';
+import { getErrorMessage } from '@utils/getErrorMessage';
 import DOMPurify from 'dompurify';
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
@@ -63,6 +65,7 @@ function ClubEditPage() {
     const [clubSummaries, setClubSummaries] = useState<ClubBoxItem[]>(defaultClubSummaries);
     const [detailImagesInFileUploader, setDetailImagesInFileUploader] = useState<File[]>([]);
     const [openClubCardDialog, setOpenClubCardDialog] = useState(false);
+    const [errorDialogOpen, setErrorDialogOpen] = useState<boolean>(false);
 
     // form hooks
     // query hooks
@@ -261,12 +264,23 @@ function ClubEditPage() {
                 toastTheme: 'white',
                 type: 'success',
             });
-        } catch (error) {
-            toast('업데이트에 실패했습니다. 다시 시도해주세요.', {
-                toastTheme: 'white',
-                type: 'error',
-            });
-            console.error(error);
+        } catch (err) {
+            // toast('업데이트에 실패했습니다. 다시 시도해주세요.', {
+            //     toastTheme: 'white',
+            //     type: 'error',
+            // });
+            // console.error(error);
+            const error = err as ErrorWithStatusCode;
+            if (error.statusCode === 500) {
+                setErrorDialogOpen(true);
+            } else if (error.response?.errors[0].message || error.message) {
+                toast(getErrorMessage(error), { type: 'error', toastTheme: 'colored' });
+            } else {
+                toast('오류로 인해 업데이트를 실패했어요.', {
+                    toastTheme: 'colored',
+                    type: 'error',
+                });
+            }
         }
     };
 
@@ -360,6 +374,11 @@ function ClubEditPage() {
                 open={openClubCardDialog}
                 onClose={() => setOpenClubCardDialog(false)}
                 club={club as unknown as Club}
+            />
+            <ErrorDialog
+                open={errorDialogOpen}
+                handleClose={() => setErrorDialogOpen(false)}
+                errorStatusCode={500}
             />
         </div>
     );

--- a/monorepo/apps/admin/src/pages/ClubMemberRolePage/ClubMemberRolePage.tsx
+++ b/monorepo/apps/admin/src/pages/ClubMemberRolePage/ClubMemberRolePage.tsx
@@ -3,7 +3,9 @@ import { roleQueries } from '@api/queryFactory/roleQueries';
 import { ErrorDialog } from '@components';
 import { ConfirmDialog } from '@components/ConfirmDialog';
 import { InviteMemberDialog } from '@components/InviteMemberDialog';
+import type { ErrorWithStatusCode } from '@pages/ErrorFallbackPage/types';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { getErrorMessage } from '@utils/getErrorMessage';
 import dayjs from 'dayjs';
 import React, { useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
@@ -62,11 +64,18 @@ const ClubMemberRolePage = () => {
                 setInviteUrl(`${origin}${invitePath}`);
                 openDialog();
             },
-            onError: (error) => {
-                if (error instanceof HttpError && error.statusCode === 500) {
-                    return;
+            onError: (err) => {
+                const error = err as ErrorWithStatusCode;
+                if (error.statusCode === 500) {
+                    setErrorDialogOpen(true);
+                } else if (error.response?.errors[0].message || error.message) {
+                    toast(getErrorMessage(error), { type: 'error', toastTheme: 'colored' });
+                } else {
+                    toast(`초대 링크 생성에 실패했어요.`, {
+                        type: 'error',
+                        toastTheme: 'colored',
+                    });
                 }
-                toast.error('초대 링크 생성에 실패했습니다.');
             },
         });
 
@@ -127,21 +136,18 @@ const ClubMemberRolePage = () => {
                 });
             },
             onError: (error) => {
+                setIsKickConfirmOpen(false);
                 if (error instanceof HttpError && error.statusCode === 500) {
-                    setIsKickConfirmOpen(false);
                     setErrorDialogOpen(true);
                     return;
                 } else if (error instanceof HttpError && error.statusCode === 400) {
                     toast.error('회장은 내보낼 수 없어요.');
-                    setIsKickConfirmOpen(false);
                     return;
                 } else if (error instanceof HttpError && error.statusCode === 403) {
                     toast.error('동아리원은 내보내기 권한이 없어요.');
-                    setIsKickConfirmOpen(false);
                     return;
                 }
                 toast.error('내보내기에 실패했습니다.');
-                setIsKickConfirmOpen(false);
             },
         });
     };

--- a/monorepo/apps/admin/src/pages/ClubMemberRolePage/ClubMemberRolePage.tsx
+++ b/monorepo/apps/admin/src/pages/ClubMemberRolePage/ClubMemberRolePage.tsx
@@ -74,6 +74,7 @@ const ClubMemberRolePage = () => {
     } = useQuery({
         ...roleQueries.getClubMemberList(clubId || ''),
         enabled: !!clubId,
+        throwOnError: true,
     });
 
     // calculated values

--- a/monorepo/apps/admin/src/pages/ClubMemberRolePage/ClubMemberRolePage.tsx
+++ b/monorepo/apps/admin/src/pages/ClubMemberRolePage/ClubMemberRolePage.tsx
@@ -1,5 +1,6 @@
 import { roleMutations } from '@api/hooks';
 import { roleQueries } from '@api/queryFactory/roleQueries';
+import { ErrorDialog } from '@components';
 import { ConfirmDialog } from '@components/ConfirmDialog';
 import { InviteMemberDialog } from '@components/InviteMemberDialog';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
@@ -44,6 +45,8 @@ const ClubMemberRolePage = () => {
     const [inviteUrl, setInviteUrl] = useState('');
     const [searchText, setSearchText] = useState('');
     const [selectedId, setSelectedId] = useState<string>('');
+    const [errorDialogOpen, setErrorDialogOpen] = useState<boolean>(false);
+
     // form hooks
     // query hooks
     const { mutate: deleteMember, isPending: isDeleting } = roleMutations.useDeleteClubMember(
@@ -125,6 +128,8 @@ const ClubMemberRolePage = () => {
             },
             onError: (error) => {
                 if (error instanceof HttpError && error.statusCode === 500) {
+                    setIsKickConfirmOpen(false);
+                    setErrorDialogOpen(true);
                     return;
                 } else if (error instanceof HttpError && error.statusCode === 400) {
                     toast.error('회장은 내보낼 수 없어요.');
@@ -261,6 +266,11 @@ const ClubMemberRolePage = () => {
                     cancelButton={true}
                     handleClose={() => setIsKickConfirmOpen(false)}
                     actionHandler={handleConfirmKickMember}
+                />
+                <ErrorDialog
+                    open={errorDialogOpen}
+                    handleClose={() => setErrorDialogOpen(false)}
+                    errorStatusCode={500}
                 />
             </div>
         </div>

--- a/monorepo/apps/admin/src/pages/DocumentEvaluationPage/DocumentEvaluationPage.tsx
+++ b/monorepo/apps/admin/src/pages/DocumentEvaluationPage/DocumentEvaluationPage.tsx
@@ -1,10 +1,12 @@
 import type { StepApplicant } from '@api/domain/step/types';
 import { applicantQueries, evaluationQueries } from '@api/queryFactory';
 import { stepQueries } from '@api/queryFactory/stepQueries';
-import { ApplicantList, EvaluationBox, InformationBox } from '@components';
+import { ApplicantList, ErrorDialog, EvaluationBox, InformationBox } from '@components';
 import { INITIAL_EVALUATION_SUMMARY } from '@constants/evaluationPage';
 import { useEvaluation } from '@hooks/components';
+import type { ErrorWithStatusCode } from '@pages/ErrorFallbackPage/types';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { getErrorMessage } from '@utils/getErrorMessage';
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
@@ -26,6 +28,7 @@ function DocumentEvaluationPage() {
     // initial values
     // state, ref, querystring hooks
     const [selectedApplicant, setSelectedApplicant] = useState<StepApplicant | null>(null);
+    const [errorDialogOpen, setErrorDialogOpen] = useState<boolean>(false);
 
     // form hooks
     // query hooks
@@ -100,11 +103,17 @@ function DocumentEvaluationPage() {
                     toastTheme: 'colored',
                 });
             },
-            onError: () => {
-                toast(`평가 ${status}에 실패했어요. 잠시 후 다시 시도해주세요!`, {
-                    type: 'error',
-                    toastTheme: 'colored',
-                });
+            onError: (error: ErrorWithStatusCode) => {
+                if (error.statusCode === 500) {
+                    setErrorDialogOpen(true);
+                } else if (error.response?.errors[0].message || error.message) {
+                    toast(getErrorMessage(error), { type: 'error', toastTheme: 'colored' });
+                } else {
+                    toast(`평가 ${status}에 실패했어요. 잠시 후 다시 시도해주세요!`, {
+                        type: 'error',
+                        toastTheme: 'colored',
+                    });
+                }
             },
         };
     }
@@ -149,6 +158,11 @@ function DocumentEvaluationPage() {
                     onUpdateComment={handleUpdateComment}
                 />
             </div>
+            <ErrorDialog
+                open={errorDialogOpen}
+                handleClose={() => setErrorDialogOpen(false)}
+                errorStatusCode={500}
+            />
         </div>
     );
 }

--- a/monorepo/apps/admin/src/pages/ErrorFallbackPage/ErrorFallbackPage.tsx
+++ b/monorepo/apps/admin/src/pages/ErrorFallbackPage/ErrorFallbackPage.tsx
@@ -24,7 +24,7 @@ import {
     s_warningIcon,
     s_warningIconWrapper,
 } from './ErrorFallbackPage.style';
-import type { ErrorFallbackPageProps } from './types';
+import type { ErrorFallbackPageProps, ErrorResponse } from './types';
 
 function ErrorFallbackPage({ error, resetErrorBoundary }: ErrorFallbackPageProps) {
     // prop destruction
@@ -52,7 +52,13 @@ function ErrorFallbackPage({ error, resetErrorBoundary }: ErrorFallbackPageProps
             message = ERROR_CODE_401;
             break;
         case 400:
-            message = ERROR_CODE_400;
+            if (error.response?.errors && Array.isArray(error.response.errors)) {
+                message = error.response.errors
+                    .map((error: ErrorResponse) => error.message)
+                    .join('\n');
+            } else {
+                message = error.message ? `${error.message} (400)` : ERROR_CODE_400;
+            }
             break;
         default:
             message = error.message ?? ERROR_DEFAULT;

--- a/monorepo/apps/admin/src/pages/ErrorFallbackPage/types.ts
+++ b/monorepo/apps/admin/src/pages/ErrorFallbackPage/types.ts
@@ -4,5 +4,13 @@ export interface ErrorFallbackPageProps {
 }
 
 export interface ErrorWithStatusCode extends Error {
-    statusCode?: number;
+    statusCode: number;
+    response?: {
+        errors: ErrorResponse[];
+    };
+}
+
+export interface ErrorResponse {
+    code: string;
+    message: string;
 }

--- a/monorepo/apps/admin/src/pages/InviteConfirmPage/InviteConfirmPage.tsx
+++ b/monorepo/apps/admin/src/pages/InviteConfirmPage/InviteConfirmPage.tsx
@@ -36,6 +36,7 @@ const InviteConfirmPage = () => {
         ...myClubQueries.getClubInfoByInviteCode(inviteCode || ''),
         enabled: !!inviteCode,
         retry: false,
+        throwOnError: true,
     });
 
     const { mutate: acceptInvite, isPending } = roleMutations.usePostInviteCode({

--- a/monorepo/apps/admin/src/pages/InviteConfirmPage/InviteConfirmPage.tsx
+++ b/monorepo/apps/admin/src/pages/InviteConfirmPage/InviteConfirmPage.tsx
@@ -1,7 +1,8 @@
 import { roleMutations } from '@api/hooks';
 import { myClubQueries } from '@api/queryFactory';
+import { ErrorDialog } from '@components';
 import { useQuery } from '@tanstack/react-query';
-import React from 'react';
+import React, { useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import { useRouter } from '@ssoc/hooks';
@@ -29,6 +30,8 @@ const InviteConfirmPage = () => {
     const accessToken = useAuthStore((state) => state.accessToken);
     // initial values
     // state, ref, querystring hooks
+    const [errorDialogOpen, setErrorDialogOpen] = useState<boolean>(false);
+
     // form hooks
     // query hooks
 
@@ -43,17 +46,17 @@ const InviteConfirmPage = () => {
         clubId: clubInfo?.id || '',
         inviteCode: inviteCode || '',
         onSuccess: () => {
-            toast.success('초대에 참여되었습니다.');
+            toast.success('초대에 참여되었어요!');
             navigate(`/settings/${clubInfo?.id}`);
         },
         onError: (error) => {
             if (error instanceof HttpError && error.statusCode === 500) {
-                return;
+                setErrorDialogOpen(true);
             } else if (error instanceof HttpError && error.statusCode === 409) {
-                toast.error('이미 초대에 참여한 동아리입니다.');
+                toast.error('이미 초대에 참여한 동아리예요!');
                 return;
             }
-            toast.error('초대 처리 중 오류가 발생했습니다.');
+            toast.error('초대 처리 중 오류가 발생했어요.');
         },
     });
 
@@ -62,7 +65,7 @@ const InviteConfirmPage = () => {
     // handlers
     const handleConfirm = async () => {
         if (!inviteCode || !clubInfo?.id) {
-            toast.error('잘못된 초대 링크입니다.');
+            toast.error('잘못된 초대 링크예요.');
             return;
         }
 
@@ -127,6 +130,11 @@ const InviteConfirmPage = () => {
                     </Button>
                 </div>
             </div>
+            <ErrorDialog
+                open={errorDialogOpen}
+                handleClose={() => setErrorDialogOpen(false)}
+                errorStatusCode={500}
+            />
         </div>
     );
 };

--- a/monorepo/apps/admin/src/pages/NonAnnouncementPage/NonAnnouncementPage.tsx
+++ b/monorepo/apps/admin/src/pages/NonAnnouncementPage/NonAnnouncementPage.tsx
@@ -37,7 +37,10 @@ function NonAnnouncementPage() {
         data: announcementList,
         isLoading,
         error,
-    } = useQuery(announcementQueries.getListByClub(clubId || '', isDialogOpen));
+    } = useQuery({
+        ...announcementQueries.getListByClub(clubId || '', isDialogOpen),
+        throwOnError: true,
+    });
 
     // calculated values
     const announcementsByStatus = useMemo(() => {

--- a/monorepo/apps/admin/src/pages/RecruitCreatePage/DescriptionStep/DescriptionStep.tsx
+++ b/monorepo/apps/admin/src/pages/RecruitCreatePage/DescriptionStep/DescriptionStep.tsx
@@ -2,9 +2,10 @@ import { DatePicker } from '@components';
 import { FieldLabel } from '@components/FieldLabel/FieldLabel';
 import { TagInput } from '@components/TagInput';
 import { DETAIL_QUESTION_LIST } from '@constants/descriptionStep';
+import dayjs from 'dayjs';
 import React from 'react';
 
-import { Editor, Input } from '@ssoc/ui';
+import { Editor, Input, useToast } from '@ssoc/ui';
 import { FileUpLoader } from '@ssoc/ui';
 
 import type { Period, RecruitDetailInfo } from '../types';
@@ -35,6 +36,8 @@ function DescriptionStepPage({
     onDetailDescriptionChange,
     isFileUploading = false,
 }: DescriptionProps) {
+    const { toast } = useToast();
+
     return (
         <>
             <div css={s_descriptionWrapper}>
@@ -93,6 +96,16 @@ function DescriptionStepPage({
                                     onChange={(dates) => {
                                         if (isPeriodField) {
                                             const [d0, d1] = (dates ?? []) as string[];
+                                            if (dayjs(d0).isBefore(dayjs(), 'day')) {
+                                                toast(
+                                                    '현재 날짜보다 이전의 날짜는 선택할 수 없어요.',
+                                                    {
+                                                        type: 'error',
+                                                        toastTheme: 'white',
+                                                    },
+                                                );
+                                                return;
+                                            }
                                             if (mode === 'range') {
                                                 onChange({
                                                     [listKey]: {

--- a/monorepo/apps/admin/src/pages/RecruitEditPage/RecruitEditPage.tsx
+++ b/monorepo/apps/admin/src/pages/RecruitEditPage/RecruitEditPage.tsx
@@ -131,7 +131,10 @@ function RecruitEditPage() {
 
     // form hooks
     // query hooks
-    const { data: detailAnnouncement } = useQuery(announcementQueries.detail(announcementId!));
+    const { data: detailAnnouncement } = useQuery({
+        ...announcementQueries.detail(announcementId!),
+        throwOnError: true,
+    });
     const { mutate: putAnnouncement } = useUpdateAnnouncement({
         clubId: clubId!,
         announcementId: announcementId!,

--- a/monorepo/apps/admin/src/pages/RecruitEditPage/RecruitEditPage.tsx
+++ b/monorepo/apps/admin/src/pages/RecruitEditPage/RecruitEditPage.tsx
@@ -142,6 +142,7 @@ function RecruitEditPage() {
                 announcementId: announcementId ?? '',
             });
             removeHistoryAndGo(afterPath);
+            toast('공고 편집이 완료되었어요!', { type: 'success', toastTheme: 'white' });
         },
         onError: () => {
             setIsDialogOpen(false);

--- a/monorepo/apps/admin/src/pages/RecruitEditPage/RecruitEditPage.tsx
+++ b/monorepo/apps/admin/src/pages/RecruitEditPage/RecruitEditPage.tsx
@@ -159,7 +159,7 @@ function RecruitEditPage() {
             } else if (error.response?.errors[0].message || error.message) {
                 toast(getErrorMessage(error), { type: 'error', toastTheme: 'colored' });
             } else {
-                toast('공고 등록에 실패했어요.', {
+                toast('공고 편집에 실패했어요.', {
                     toastTheme: 'colored',
                     type: 'error',
                 });

--- a/monorepo/apps/admin/src/pages/StepManagementPage/StepManagementPage.tsx
+++ b/monorepo/apps/admin/src/pages/StepManagementPage/StepManagementPage.tsx
@@ -263,7 +263,7 @@ function StepManagementPage() {
                         } else if (error.response?.errors[0].message || error.message) {
                             toast(getErrorMessage(error), { type: 'error', toastTheme: 'colored' });
                         } else {
-                            toast('오류로 인해 일정 변경을 못했어요.', {
+                            toast('오류로 인해 상태 변경을 못했어요.', {
                                 toastTheme: 'colored',
                                 type: 'error',
                             });

--- a/monorepo/apps/admin/src/pages/UserSettingPage/UserSettingPage.tsx
+++ b/monorepo/apps/admin/src/pages/UserSettingPage/UserSettingPage.tsx
@@ -64,9 +64,6 @@ function UserSettingPage() {
             }
         },
         onError: (err) => {
-            // if (error instanceof HttpError && error.statusCode === 500) {
-            //     return;
-            // }
             const error = err as ErrorWithStatusCode;
             if (error.statusCode === 500) {
                 setErrorDialogOpen(true);
@@ -78,7 +75,6 @@ function UserSettingPage() {
                     type: 'error',
                 });
             }
-            // toast.error('프로필 사진 업데이트에 실패했습니다.');
         },
     });
     //calculated values

--- a/monorepo/apps/admin/src/pages/UserSettingPage/UserSettingPage.tsx
+++ b/monorepo/apps/admin/src/pages/UserSettingPage/UserSettingPage.tsx
@@ -2,9 +2,11 @@ import { HttpError } from '@api/common/httpError';
 import { useUserMutation } from '@api/hooks/userMutations';
 import { myClubQueries } from '@api/queryFactory';
 import { userQueries } from '@api/queryFactory/userQueries';
-import { ImageRegister } from '@components';
+import { ErrorDialog, ImageRegister } from '@components';
 import { BASE_URL } from '@constants/api';
+import type { ErrorWithStatusCode } from '@pages/ErrorFallbackPage/types';
 import { useSuspenseQuery } from '@tanstack/react-query';
+import { getErrorMessage } from '@utils/getErrorMessage';
 import React, { useEffect, useState } from 'react';
 
 import { useRouter } from '@ssoc/hooks';
@@ -45,6 +47,8 @@ function UserSettingPage() {
     const [isProfileModifyMode, setIsProfileModifyMode] = useState(false);
     const [image, setImage] = useState<string>(BasicImage);
     const [croppedImage, setCroppedImage] = useState<string>(BasicImage);
+    const [errorDialogOpen, setErrorDialogOpen] = useState<boolean>(false);
+
     //form hooks
     //query hooks
     const { data: myClubs } = useSuspenseQuery(myClubQueries.all());
@@ -59,11 +63,22 @@ function UserSettingPage() {
                 setCroppedImage(data.representativeImage.url);
             }
         },
-        onError: (error) => {
-            if (error instanceof HttpError && error.statusCode === 500) {
-                return;
+        onError: (err) => {
+            // if (error instanceof HttpError && error.statusCode === 500) {
+            //     return;
+            // }
+            const error = err as ErrorWithStatusCode;
+            if (error.statusCode === 500) {
+                setErrorDialogOpen(true);
+            } else if (error.response?.errors[0].message || error.message) {
+                toast(getErrorMessage(error), { type: 'error', toastTheme: 'colored' });
+            } else {
+                toast('프로필 사진 업데이트에 실패했어요.', {
+                    toastTheme: 'colored',
+                    type: 'error',
+                });
             }
-            toast.error('프로필 사진 업데이트에 실패했습니다.');
+            // toast.error('프로필 사진 업데이트에 실패했습니다.');
         },
     });
     //calculated values
@@ -253,6 +268,11 @@ function UserSettingPage() {
                     수정완료
                 </Button>
             )}
+            <ErrorDialog
+                open={errorDialogOpen}
+                handleClose={() => setErrorDialogOpen(false)}
+                errorStatusCode={500}
+            />
         </div>
     );
 }

--- a/monorepo/apps/admin/src/utils/getErrorMessage.ts
+++ b/monorepo/apps/admin/src/utils/getErrorMessage.ts
@@ -31,3 +31,20 @@ export const getErrorMessage = (error: ErrorWithStatusCode): string => {
             return error.message ?? ERROR_DEFAULT;
     }
 };
+
+export const getErrorPlainMessageByErrorStatusCode = (errorStatusCode: number): string => {
+    switch (errorStatusCode) {
+        case 500:
+            return ERROR_CODE_500;
+        case 404:
+            return ERROR_CODE_404_DATA;
+        case 403:
+            return ERROR_CODE_403;
+        case 401:
+            return ERROR_CODE_401;
+        case 400:
+            return ERROR_CODE_400;
+        default:
+            return ERROR_DEFAULT;
+    }
+};

--- a/monorepo/apps/admin/src/utils/getErrorMessage.ts
+++ b/monorepo/apps/admin/src/utils/getErrorMessage.ts
@@ -1,0 +1,33 @@
+import {
+    ERROR_CODE_400,
+    ERROR_CODE_401,
+    ERROR_CODE_403,
+    ERROR_CODE_404_DATA,
+    ERROR_CODE_500,
+    ERROR_DEFAULT,
+} from '@constants/errorText';
+import type { ErrorWithStatusCode } from '@pages/ErrorFallbackPage/types';
+
+export const getErrorMessage = (error: ErrorWithStatusCode): string => {
+    switch (error.statusCode) {
+        case 500:
+            return ERROR_CODE_500;
+        case 404:
+            return ERROR_CODE_404_DATA;
+        case 403:
+            return ERROR_CODE_403;
+        case 401:
+            return ERROR_CODE_401;
+        case 400:
+            if (
+                error.response?.errors &&
+                Array.isArray(error.response.errors) &&
+                error.response.errors.length > 0
+            ) {
+                return error.response.errors[0].message;
+            }
+            return error.message ? `${error.message} (400)` : ERROR_CODE_400;
+        default:
+            return error.message ?? ERROR_DEFAULT;
+    }
+};

--- a/monorepo/apps/user/src/api/hooks/clubMutation.ts
+++ b/monorepo/apps/user/src/api/hooks/clubMutation.ts
@@ -1,12 +1,18 @@
 import { submitInterviewReservation } from '@api/domain/club/club';
 import { clubKeys } from '@api/querykeyFactory';
+import type { ErrorWithStatusCode } from '@pages/ErrorFallbackPage/types';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { returnErrorMessage } from '@utils/getErrorMessage';
+
+import { useToast } from '@ssoc/ui';
 
 import { HttpError } from '../common/httpError';
 import type { InterviewReservationParams } from './types';
 
-const useSubmitInterviewReservation = () => {
+const useSubmitInterviewReservation = (onErrorDialogOpen: (open: boolean) => void) => {
     const queryClient = useQueryClient();
+    const { toast } = useToast();
+
     return useMutation({
         mutationFn: ({
             clubId = '',
@@ -18,11 +24,19 @@ const useSubmitInterviewReservation = () => {
             return response;
         },
         onError: (
-            error,
+            err,
             { clubId = '', announcementId = '', applicantId = '' }: InterviewReservationParams,
         ) => {
-            if (error instanceof HttpError && error.statusCode === 500) {
-                return;
+            const error = err as ErrorWithStatusCode;
+            if (error.statusCode === 500) {
+                onErrorDialogOpen(true);
+            } else if (error.response?.errors[0].message || error.message) {
+                toast(returnErrorMessage(error), { type: 'error', toastTheme: 'colored' });
+            } else {
+                toast('오류로 인해 예약에 실패했어요.', {
+                    toastTheme: 'colored',
+                    type: 'error',
+                });
             }
             queryClient.invalidateQueries({
                 queryKey: clubKeys.reservation(clubId, announcementId, applicantId),

--- a/monorepo/apps/user/src/components/ErrorDialog/ErrorDialog.tsx
+++ b/monorepo/apps/user/src/components/ErrorDialog/ErrorDialog.tsx
@@ -1,13 +1,5 @@
-import {
-    DEFAULT_DESCRIPTION,
-    ERROR_500_DESCRIPTION,
-    ERROR_CODE_400,
-    ERROR_CODE_401,
-    ERROR_CODE_403,
-    ERROR_CODE_404_DATA,
-    ERROR_CODE_500,
-    ERROR_DEFAULT,
-} from '@constants/errorText';
+import { DEFAULT_DESCRIPTION, ERROR_500_DESCRIPTION } from '@constants/errorText';
+import { getErrorPlainMessageByErrorStatusCode } from '@utils/getErrorMessage';
 import React from 'react';
 
 import { useRouter } from '@ssoc/hooks';
@@ -28,33 +20,12 @@ function ErrorDialog({
     const { goTo } = useRouter();
 
     // initial values
-    let message = ERROR_DEFAULT;
+    let message = getErrorPlainMessageByErrorStatusCode(errorStatusCode);
 
     // state, ref, querystring hooks
     // form hooks
     // query hooks
     // calculated values
-    switch (errorStatusCode) {
-        case 500:
-            message = ERROR_CODE_500;
-            break;
-        case 404:
-            message = ERROR_CODE_404_DATA;
-            break;
-        case 403:
-            message = ERROR_CODE_403;
-            break;
-        case 401:
-            message = ERROR_CODE_401;
-            break;
-        case 400:
-            message = ERROR_CODE_400;
-            break;
-        default:
-            message = ERROR_DEFAULT;
-            break;
-    }
-
     if (content) message = content;
 
     // handlers

--- a/monorepo/apps/user/src/components/ErrorDialog/type.ts
+++ b/monorepo/apps/user/src/components/ErrorDialog/type.ts
@@ -1,7 +1,7 @@
 export interface ErrorDialogProps {
     open: boolean;
     handleClose: () => void;
-    errorStatusCode?: number;
+    errorStatusCode: number;
     content?: string;
     subContent?: string;
 }

--- a/monorepo/apps/user/src/index.tsx
+++ b/monorepo/apps/user/src/index.tsx
@@ -33,14 +33,14 @@ function handleGlobalError(error: unknown) {
 const queryClient = new QueryClient({
     queryCache: new QueryCache({
         onError: (error) => {
-            handleGlobalError(error);
+            throw error;
         },
     }),
-    mutationCache: new MutationCache({
-        onError: (error) => {
-            handleGlobalError(error);
-        },
-    }),
+    // mutationCache: new MutationCache({
+    //     onError: (error) => {
+    //         handleGlobalError(error);
+    //     },
+    // }),
 });
 
 function ToastManager() {

--- a/monorepo/apps/user/src/pages/ClubApplyPage/ClubApplyPage.tsx
+++ b/monorepo/apps/user/src/pages/ClubApplyPage/ClubApplyPage.tsx
@@ -73,8 +73,9 @@ function ClubApplyPage() {
             goTo(`success/${response.applicantId}/${response.applicationId}`);
         },
         onError: (error) => {
+            setIsSubmitDialogOpen(false);
+
             if (error instanceof HttpError && error.statusCode === 500) {
-                setIsSubmitDialogOpen(false);
                 setErrorDialogOpen(true);
                 return;
             } else if (error instanceof HttpError && error.statusCode === 409) {
@@ -82,22 +83,20 @@ function ClubApplyPage() {
 
                 if (errorResponse?.code === 'DUPLICATE_APPLICATION') {
                     toast.error('이미 해당 공고에 지원한 이메일입니다.');
-                    setIsSubmitDialogOpen(false);
                     return;
                 }
-            } else if (
-                (error as ErrorWithStatusCode).response?.errors[0].message ||
-                (error as ErrorWithStatusCode).message
-            ) {
-                setIsSubmitDialogOpen(false);
+            }
+
+            const err = error as ErrorWithStatusCode;
+            if (err.response?.errors[0].message || err.message) {
                 toast(returnErrorMessage(error as ErrorWithStatusCode), {
                     type: 'error',
                     toastTheme: 'colored',
                 });
                 return;
             }
+
             toast.error('제출에 실패했어요.');
-            setIsSubmitDialogOpen(false);
         },
     });
 

--- a/monorepo/apps/user/src/pages/ClubDetailPage/RecruitmentPage/RecruitmentPage.tsx
+++ b/monorepo/apps/user/src/pages/ClubDetailPage/RecruitmentPage/RecruitmentPage.tsx
@@ -37,11 +37,13 @@ function RecruitmentPage() {
     } = useQuery({
         ...announcementQueries.getAnnouncementList(clubId || ''),
         enabled: !!clubId,
+        throwOnError: true,
     });
 
     const { data: selectedAnnouncementDetail } = useQuery({
         ...announcementQueries.getAnnouncementDetail(selectedAnnouncementId),
         enabled: !!selectedAnnouncementId,
+        throwOnError: true,
     });
 
     // calculated values

--- a/monorepo/apps/user/src/pages/ErrorFallbackPage/ErrorFallbackPage.tsx
+++ b/monorepo/apps/user/src/pages/ErrorFallbackPage/ErrorFallbackPage.tsx
@@ -3,6 +3,7 @@ import {
     DEFAULT_DESCRIPTION,
     ERROR_500_DESCRIPTION,
     ERROR_CODE_400,
+    ERROR_CODE_401,
     ERROR_CODE_403,
     ERROR_CODE_404_DATA,
     ERROR_CODE_500,
@@ -23,7 +24,7 @@ import {
     s_warningIcon,
     s_warningIconWrapper,
 } from './ErrorFallbackPage.style';
-import type { ErrorFallbackPageProps } from './types';
+import type { ErrorFallbackPageProps, ErrorResponse } from './types';
 
 function ErrorFallbackPage({ error, resetErrorBoundary }: ErrorFallbackPageProps) {
     // prop destruction
@@ -47,8 +48,17 @@ function ErrorFallbackPage({ error, resetErrorBoundary }: ErrorFallbackPageProps
         case 403:
             message = ERROR_CODE_403;
             break;
+        case 401:
+            message = ERROR_CODE_401;
+            break;
         case 400:
-            message = ERROR_CODE_400;
+            if (error.response?.errors && Array.isArray(error.response.errors)) {
+                message = error.response.errors
+                    .map((error: ErrorResponse) => error.message)
+                    .join('\n');
+            } else {
+                message = error.message ? `${error.message} (400)` : ERROR_CODE_400;
+            }
             break;
         default:
             message = error.message ?? ERROR_DEFAULT;
@@ -81,17 +91,16 @@ function ErrorFallbackPage({ error, resetErrorBoundary }: ErrorFallbackPageProps
                     <Button onClick={() => goTo('/')}>오류 신고</Button>
                     <Button onClick={resetErrorBoundary}>다시 시도</Button>
                 </div>
+            ) : error.statusCode === 401 ? (
+                <div css={s_buttonContainer}>
+                    <Button onClick={() => goTo('/login')}>로그인 하기</Button>
+                </div>
             ) : (
                 <div css={s_buttonContainer}>
                     <Button onClick={resetErrorBoundary}>다시 시도</Button>
                 </div>
             )}
-            <Button
-                size="xs"
-                variant="text"
-                onClick={() => (window.location.href = '/')}
-                sx={s_homeTextButton}
-            >
+            <Button size="xs" variant="text" onClick={() => goTo('/')} sx={s_homeTextButton}>
                 처음으로
             </Button>
         </div>

--- a/monorepo/apps/user/src/pages/ErrorFallbackPage/types.ts
+++ b/monorepo/apps/user/src/pages/ErrorFallbackPage/types.ts
@@ -4,5 +4,13 @@ export interface ErrorFallbackPageProps {
 }
 
 export interface ErrorWithStatusCode extends Error {
-    statusCode?: number;
+    statusCode: number;
+    response?: {
+        errors: ErrorResponse[];
+    };
+}
+
+export interface ErrorResponse {
+    code: string;
+    message: string;
 }

--- a/monorepo/apps/user/src/pages/ReservationPage/ReservationPage.tsx
+++ b/monorepo/apps/user/src/pages/ReservationPage/ReservationPage.tsx
@@ -57,9 +57,10 @@ function ReservationPage() {
     const [isSuccessReservation, setIsSuccessReservation] = useState<boolean>(true);
     // form hooks
     // query hooks
-    const { data: clubReservation } = useQuery(
-        clubQueries.getClubReservation(clubId ?? '', announcementId ?? '', applicantId ?? ''),
-    );
+    const { data: clubReservation } = useQuery({
+        ...clubQueries.getClubReservation(clubId ?? '', announcementId ?? '', applicantId ?? ''),
+        throwOnError: true,
+    });
     const { mutateAsync: submitInterviewReservation } = useSubmitInterviewReservation();
     // calculated values
 

--- a/monorepo/apps/user/src/pages/ReservationPage/ReservationPage.tsx
+++ b/monorepo/apps/user/src/pages/ReservationPage/ReservationPage.tsx
@@ -3,6 +3,7 @@ import { useSubmitInterviewReservation } from '@api/hooks';
 import { clubQueries } from '@api/queryFactory/clubQueries';
 import Clock from '@assets/images/clock.svg';
 import User from '@assets/images/user.svg';
+import { ErrorDialog } from '@components';
 import { useQuery } from '@tanstack/react-query';
 import { getCategory } from '@utils/changeCategory';
 import dayjs from 'dayjs';
@@ -55,13 +56,16 @@ function ReservationPage() {
     const [interviewDuration, setInterviewDuration] = useState<number>(0);
     const [selectedInterviewSlot, setSelectedInterviewSlot] = useState<InterviewSlot | null>(null);
     const [isSuccessReservation, setIsSuccessReservation] = useState<boolean>(true);
+    const [errorDialogOpen, setErrorDialogOpen] = useState<boolean>(false);
+
     // form hooks
     // query hooks
     const { data: clubReservation } = useQuery({
         ...clubQueries.getClubReservation(clubId ?? '', announcementId ?? '', applicantId ?? ''),
         throwOnError: true,
     });
-    const { mutateAsync: submitInterviewReservation } = useSubmitInterviewReservation();
+    const { mutateAsync: submitInterviewReservation } =
+        useSubmitInterviewReservation(setErrorDialogOpen);
     // calculated values
 
     // handlers
@@ -282,6 +286,11 @@ function ReservationPage() {
                         content={`${dayjs(selectedInterviewSlot?.period.startDate).format('YYYY년 MM월 DD일 HH:mm\n')} 예약하시겠습니까?`}
                     />
                 )}
+                <ErrorDialog
+                    open={errorDialogOpen}
+                    handleClose={() => setErrorDialogOpen(false)}
+                    errorStatusCode={500}
+                />
             </div>
         );
     }

--- a/monorepo/apps/user/src/utils/getErrorMessage.ts
+++ b/monorepo/apps/user/src/utils/getErrorMessage.ts
@@ -1,0 +1,50 @@
+import {
+    ERROR_CODE_400,
+    ERROR_CODE_401,
+    ERROR_CODE_403,
+    ERROR_CODE_404_DATA,
+    ERROR_CODE_500,
+    ERROR_DEFAULT,
+} from '@constants/errorText';
+import type { ErrorWithStatusCode } from '@pages/ErrorFallbackPage/types';
+
+export const getErrorMessage = (error: ErrorWithStatusCode): string => {
+    switch (error.statusCode) {
+        case 500:
+            return ERROR_CODE_500;
+        case 404:
+            return ERROR_CODE_404_DATA;
+        case 403:
+            return ERROR_CODE_403;
+        case 401:
+            return ERROR_CODE_401;
+        case 400:
+            if (
+                error.response?.errors &&
+                Array.isArray(error.response.errors) &&
+                error.response.errors.length > 0
+            ) {
+                return error.response.errors[0].message;
+            }
+            return error.message ? `${error.message} (400)` : ERROR_CODE_400;
+        default:
+            return error.message ?? ERROR_DEFAULT;
+    }
+};
+
+export const getErrorPlainMessageByErrorStatusCode = (errorStatusCode: number): string => {
+    switch (errorStatusCode) {
+        case 500:
+            return ERROR_CODE_500;
+        case 404:
+            return ERROR_CODE_404_DATA;
+        case 403:
+            return ERROR_CODE_403;
+        case 401:
+            return ERROR_CODE_401;
+        case 400:
+            return ERROR_CODE_400;
+        default:
+            return ERROR_DEFAULT;
+    }
+};

--- a/monorepo/apps/user/src/utils/getErrorMessage.ts
+++ b/monorepo/apps/user/src/utils/getErrorMessage.ts
@@ -8,7 +8,7 @@ import {
 } from '@constants/errorText';
 import type { ErrorWithStatusCode } from '@pages/ErrorFallbackPage/types';
 
-export const getErrorMessage = (error: ErrorWithStatusCode): string => {
+export const returnErrorMessage = (error: ErrorWithStatusCode): string => {
     switch (error.statusCode) {
         case 500:
             return ERROR_CODE_500;


### PR DESCRIPTION
## 📌 관련 이슈
`closed #458 `

## 🛠️ 작업 내용
- [x] ErrorBoundary 사용할 수 있도록 throwOnError 설정
- [x] mutation 별 error ui 띄우도록 설정
- [x] 공고 생성, 편집 페이지 내에서 사용되는 datePicker 로직 수정

## 🎯 리뷰 포인트


## ⏳ 작업 시간
추정 시간:  8시간
실제 시간:  8시간