### PR TITLE
[BE] 서비스 QA 도중 발생한 예외 수정 작업

### DIFF
--- a/server/src/main/java/com/ryc/api/v2/common/deserializer/EmptyStringToNullLocalDateTimeDeserializer.java
+++ b/server/src/main/java/com/ryc/api/v2/common/deserializer/EmptyStringToNullLocalDateTimeDeserializer.java
@@ -1,0 +1,31 @@
+package com.ryc.api.v2.common.deserializer;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+public class EmptyStringToNullLocalDateTimeDeserializer extends JsonDeserializer<LocalDateTime> {
+
+  private static final DateTimeFormatter FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm");
+
+  @Override
+  public LocalDateTime deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    String value = p.getText();
+
+    if (value == null || value.trim().isEmpty()) {
+      return null;
+    }
+
+    try {
+      return LocalDateTime.parse(value, FORMATTER);
+    } catch (Exception e) {
+      throw new IllegalArgumentException(
+          "Invalid date format: " + value + ". Expected format: yyyy-MM-ddTHH:mm");
+    }
+  }
+}

--- a/server/src/main/java/com/ryc/api/v2/common/deserializer/EndOfDayLocalDateTimeDeserializer.java
+++ b/server/src/main/java/com/ryc/api/v2/common/deserializer/EndOfDayLocalDateTimeDeserializer.java
@@ -1,0 +1,35 @@
+package com.ryc.api.v2.common.deserializer;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.ryc.api.v2.common.exception.code.CommonErrorCode;
+import com.ryc.api.v2.common.exception.custom.InvalidFormatException;
+
+/** 종료 날짜용 Deserializer */
+public class EndOfDayLocalDateTimeDeserializer extends JsonDeserializer<LocalDateTime> {
+
+  private static final DateTimeFormatter FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm");
+
+  @Override
+  public LocalDateTime deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    String value = p.getText();
+
+    if (value == null || value.trim().isEmpty()) {
+      return null;
+    }
+
+    try {
+      LocalDateTime dateTime = LocalDateTime.parse(value, FORMATTER);
+      return dateTime.toLocalDate().atTime(23, 59, 59); // 23:59:59
+    } catch (Exception e) {
+      // TODO: 메시지 추가
+      throw new InvalidFormatException(CommonErrorCode.INVALID_PARAMETER);
+    }
+  }
+}

--- a/server/src/main/java/com/ryc/api/v2/common/deserializer/StartOfDayLocalDateTimeDeserializer.java
+++ b/server/src/main/java/com/ryc/api/v2/common/deserializer/StartOfDayLocalDateTimeDeserializer.java
@@ -1,0 +1,35 @@
+package com.ryc.api.v2.common.deserializer;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.ryc.api.v2.common.exception.code.CommonErrorCode;
+import com.ryc.api.v2.common.exception.custom.InvalidFormatException;
+
+/** 시작 날짜용 Deserializer */
+public class StartOfDayLocalDateTimeDeserializer extends JsonDeserializer<LocalDateTime> {
+
+  private static final DateTimeFormatter FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm");
+
+  @Override
+  public LocalDateTime deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    String value = p.getText();
+
+    if (value == null || value.trim().isEmpty()) {
+      return null;
+    }
+
+    try {
+      LocalDateTime dateTime = LocalDateTime.parse(value, FORMATTER);
+      return dateTime.toLocalDate().atStartOfDay(); // 00:00:00
+    } catch (Exception e) {
+      // TODO: 메시지 추가
+      throw new InvalidFormatException(CommonErrorCode.INVALID_PARAMETER);
+    }
+  }
+}

--- a/server/src/main/java/com/ryc/api/v2/common/domain/Period.java
+++ b/server/src/main/java/com/ryc/api/v2/common/domain/Period.java
@@ -16,7 +16,12 @@ public record Period(LocalDateTime startDate, LocalDateTime endDate) {
 
   @Builder
   public Period {
-    PeriodValidator.validate(startDate, endDate);
+    LocalDateTime normalizedStartDate =
+        startDate() != null ? startDate().toLocalDate().atStartOfDay() : null;
+    LocalDateTime normalizedEndDate =
+        endDate() != null ? endDate().toLocalDate().atTime(23, 59, 59) : null;
+
+    PeriodValidator.validate(normalizedStartDate, normalizedEndDate);
   }
 
   public static Period from(PeriodRequest periodRequest) {

--- a/server/src/main/java/com/ryc/api/v2/common/domain/PeriodValidator.java
+++ b/server/src/main/java/com/ryc/api/v2/common/domain/PeriodValidator.java
@@ -19,10 +19,10 @@ final class PeriodValidator extends DomainValidator {
 
   /** 검증 private 헬퍼 메소드 */
   private static void validateStartDate(LocalDateTime startDate) {
-    validateNotNull(startDate, PERIOD_START_DATE_NULL);
+    // 기타 Null 허용 기한(예: 서류합격 시작일, 면접시작일, 최종합격자 발표 시작일)
   }
 
   private static void validateEndDate(LocalDateTime endDate) {
-    validateNotNull(endDate, PERIOD_END_DATE_NULL);
+    // 기타 Null 허용 기한(예: 서류합격 종료일, 면접종료일, 최종합격자 발표 종료일)
   }
 }

--- a/server/src/main/java/com/ryc/api/v2/common/dto/request/PeriodRequest.java
+++ b/server/src/main/java/com/ryc/api/v2/common/dto/request/PeriodRequest.java
@@ -3,7 +3,8 @@ package com.ryc.api.v2.common.dto.request;
 import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.ryc.api.v2.common.deserializer.EmptyStringToNullLocalDateTimeDeserializer;
+import com.ryc.api.v2.common.deserializer.EndOfDayLocalDateTimeDeserializer;
+import com.ryc.api.v2.common.deserializer.StartOfDayLocalDateTimeDeserializer;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -21,12 +22,12 @@ public record PeriodRequest(
             pattern = "yyyy-MM-dd'T'HH:mm",
             description = "시작 날짜",
             example = "2025-06-29T00:00")
-        @JsonDeserialize(using = EmptyStringToNullLocalDateTimeDeserializer.class)
+        @JsonDeserialize(using = StartOfDayLocalDateTimeDeserializer.class)
         LocalDateTime startDate,
     @Schema(
             type = "string",
             pattern = "yyyy-MM-dd'T'HH:mm",
             description = "끝 날짜",
-            example = "2025-07-20T00:00")
-        @JsonDeserialize(using = EmptyStringToNullLocalDateTimeDeserializer.class)
+            example = "2025-07-20T23:59")
+        @JsonDeserialize(using = EndOfDayLocalDateTimeDeserializer.class)
         LocalDateTime endDate) {}

--- a/server/src/main/java/com/ryc/api/v2/common/dto/request/PeriodRequest.java
+++ b/server/src/main/java/com/ryc/api/v2/common/dto/request/PeriodRequest.java
@@ -2,7 +2,8 @@ package com.ryc.api.v2.common.dto.request;
 
 import java.time.LocalDateTime;
 
-import org.springframework.format.annotation.DateTimeFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.ryc.api.v2.common.deserializer.EmptyStringToNullLocalDateTimeDeserializer;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -20,12 +21,12 @@ public record PeriodRequest(
             pattern = "yyyy-MM-dd'T'HH:mm",
             description = "시작 날짜",
             example = "2025-06-29T00:00")
-        @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
+        @JsonDeserialize(using = EmptyStringToNullLocalDateTimeDeserializer.class)
         LocalDateTime startDate,
     @Schema(
             type = "string",
             pattern = "yyyy-MM-dd'T'HH:mm",
             description = "끝 날짜",
             example = "2025-07-20T00:00")
-        @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
+        @JsonDeserialize(using = EmptyStringToNullLocalDateTimeDeserializer.class)
         LocalDateTime endDate) {}

--- a/server/src/main/java/com/ryc/api/v2/common/validator/DomainValidator.java
+++ b/server/src/main/java/com/ryc/api/v2/common/validator/DomainValidator.java
@@ -99,6 +99,8 @@ public abstract class DomainValidator {
   /** 유효한 시간 범위 검증 */
   protected static void validateDateRange(
       LocalDateTime startDate, LocalDateTime endDate, ErrorCode errorCode) {
+    // null 값에 대해 범위체크 생략
+    if (startDate == null || endDate == null) return;
     if (startDate.isAfter(endDate)) {
       throw new InvalidFormatException(errorCode);
     }

--- a/server/src/main/java/com/ryc/api/v2/interview/presentation/dto/request/NumberOfPeopleByInterviewDateRequest.java
+++ b/server/src/main/java/com/ryc/api/v2/interview/presentation/dto/request/NumberOfPeopleByInterviewDateRequest.java
@@ -6,14 +6,15 @@ import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
-import org.springframework.format.annotation.DateTimeFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.ryc.api.v2.common.deserializer.EmptyStringToNullLocalDateTimeDeserializer;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record NumberOfPeopleByInterviewDateRequest(
     @Schema(description = "면접 시작 날짜와 시간")
         @NotNull(message = "면접 시작 날짜와 시간은 null일 수 없습니다.")
-        @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
+        @JsonDeserialize(using = EmptyStringToNullLocalDateTimeDeserializer.class)
         @Future(message = "면접 시작 시간은 미래의 시간이여야 합니다.")
         LocalDateTime start,
     @Schema(description = "면접 당 진행 시간(분)")

--- a/server/src/main/java/com/ryc/api/v2/role/domain/ClubRoleValidator.java
+++ b/server/src/main/java/com/ryc/api/v2/role/domain/ClubRoleValidator.java
@@ -7,7 +7,6 @@ import java.util.regex.Pattern;
 
 import com.ryc.api.v2.admin.domain.Admin;
 import com.ryc.api.v2.club.domain.Club;
-import com.ryc.api.v2.common.constant.DomainDefaultValues;
 import com.ryc.api.v2.common.validator.DomainValidator;
 import com.ryc.api.v2.role.domain.enums.Role;
 
@@ -45,9 +44,5 @@ final class ClubRoleValidator extends DomainValidator {
     validateNotNull(admin, CLUB_ROLE_ADMIN_NULL);
   }
 
-  private static void validateJoinedAt(String id, LocalDateTime joinedAt) {
-    // 영속화 이전은 NULL 허용
-    if (id.equals(DomainDefaultValues.DEFAULT_INITIAL_ID)) return;
-    validateNotNull(joinedAt, CLUB_ROLE_JOINED_AT_NULL);
-  }
+  private static void validateJoinedAt(String id, LocalDateTime joinedAt) {}
 }


### PR DESCRIPTION
## 📌 관련 이슈
closed #468 

## 🛠️ 작업 내용
PR에서 작업한 주요 내용을 적어주세요.
- [x] 현재 기한이 빈경우 클라이언트에서 null이 아닌 ""를 입력값으로 전송. 이에 따라 LocalDateTime 변환 오류 발생. 커스텀 역직렬화 어노테이션 구현 예정
- [x] joinedAt null 허용 -> 영속성 레이어 통과할 때만, Null 제한
- [x] 서버 시간 한국시간으로 수정

현지 테스트 결과 로컬시간이 프랑스 시간으로 7시간 뒤 한국시간에 맞게 작성됨을 확인하였습니다.
만일 배포이후에도 로컬시간이 반영된다면 수정 필요합니다. 

## ⏳ 작업 시간
추정 시간: 1시간   
실제 시간:   2시간
