### PR TITLE
[BE/HOTFIX] QA도중 발견한 서버 검증 버그 및 기타 버그

### DIFF
--- a/server/src/main/java/com/ryc/api/v2/announcement/domain/Announcement.java
+++ b/server/src/main/java/com/ryc/api/v2/announcement/domain/Announcement.java
@@ -206,14 +206,18 @@ public class Announcement {
     // 생성시에는 모집 예정, 모집 중
     if (id.equals(DomainDefaultValues.DEFAULT_INITIAL_ID)) {
       if (announcementStatus == AnnouncementStatus.CLOSED) {
+        // TODO: 에러 메시지 및 코드 적절하지 않음. 수정 필요
         throw new BusinessRuleException(AnnouncementErrorCode.INVALID_ANNOUNCEMENT_STATUS);
       }
     }
     // 업데이트시 모집 예정일 때만 수정가능
+    // 25.08.29(조상준) 중요: 아래 코드 비활성화 -> 업데이트시 기존공고객체, 수정된 공고객체 모두 아래 else문을 통과하기에,
+    // 수정된 공고의 상태가 UPCOMING가 이닌, 모집중, 마김인 경우 아래 else문에서 에러 발생.
+    // 따라서, 기존공고의 상태가 UPCOMING인지는 공고 수정 서비스에서 상태검증으로 작성.
     else {
-      if (!(announcementStatus == AnnouncementStatus.UPCOMING)) {
-        throw new BusinessRuleException(AnnouncementErrorCode.INVALID_ANNOUNCEMENT_STATUS);
-      }
+      //      if (!(announcementStatus == AnnouncementStatus.UPCOMING)) {
+      //        throw new BusinessRuleException(AnnouncementErrorCode.INVALID_ANNOUNCEMENT_STATUS);
+      //      }
     }
 
     applicationForm.checkBusinessRules();

--- a/server/src/main/java/com/ryc/api/v2/announcement/domain/AnnouncementValidator.java
+++ b/server/src/main/java/com/ryc/api/v2/announcement/domain/AnnouncementValidator.java
@@ -25,7 +25,7 @@ final class AnnouncementValidator extends DomainValidator {
 
   // 공통 상수
   private static final int MIN_TITLE_LENGTH = 2;
-  private static final int MAX_TITLE_LENGTH = 100;
+  private static final int MAX_TITLE_LENGTH = 200;
   private static final int MAX_DESCRIPTION_LENGTH = 10000;
   private static final int MAX_SUMMARY_DESCRIPTION_LENGTH = 300;
   private static final int MAX_TARGET_LENGTH = 50;

--- a/server/src/main/java/com/ryc/api/v2/announcement/domain/vo/AnnouncementPeriodInfo.java
+++ b/server/src/main/java/com/ryc/api/v2/announcement/domain/vo/AnnouncementPeriodInfo.java
@@ -13,6 +13,12 @@ import lombok.Builder;
  * @param finalResultPeriod 최종발표 기간
  * @param documentResultPeriod 서류 결과 발표 기간 (면접 진행시)
  */
+
+/**
+ * 중요(조상준): 상시모집 케이스 때문에 서버에서는 날짜 순위 검증을 불필요하게 할 이유 없음 (applicationPeriod < interviewPeriod <
+ * finalResultPeriod < documentResultPeriod) 현재 서비스 내에서는 각 기간의 시작/종료일 검증만 기능적으로 필요하며, 각 기한 종류간의
+ * 상하관계는 기능에서 사용되거나 필요하지 않음. (기준일: 25.08.29) 오히려 해당 검증이 수반된다면, 현재 상시모집의 경우 오류 발생. 따라서 해당 검증 추가 금지.
+ */
 public record AnnouncementPeriodInfo(
     Period applicationPeriod, // 이 필드만 필수입력
     Period interviewPeriod,

--- a/server/src/main/java/com/ryc/api/v2/announcement/presentation/dto/request/AnnouncementCreateRequest.java
+++ b/server/src/main/java/com/ryc/api/v2/announcement/presentation/dto/request/AnnouncementCreateRequest.java
@@ -30,7 +30,7 @@ import lombok.Builder;
 public record AnnouncementCreateRequest(
     @Schema(description = "공고 제목", example = "2025년도 상반기 신입 모집")
         @NotBlank(message = "공고 제목은 필수 항목입니다.")
-        @Size(min = 2, max = 100, message = "공고 제목의 길이는 2자 이상 100자 이하입니다.")
+        @Size(min = 2, max = 200, message = "공고 제목의 길이는 2자 이상 200자 이하입니다.")
         String title,
     @Schema(description = "기간 정보")
         @NotNull(message = "공고 기한 정보 필드는 빈값일 수 없습니다. 최소 지원서 접수기간은 필수 입력해주십시오.")

--- a/server/src/main/java/com/ryc/api/v2/announcement/presentation/dto/request/AnnouncementCreateRequest.java
+++ b/server/src/main/java/com/ryc/api/v2/announcement/presentation/dto/request/AnnouncementCreateRequest.java
@@ -60,7 +60,10 @@ public record AnnouncementCreateRequest(
             allowableValues = {"ALWAYS_OPEN", "LIMITED_TIME"})
         @NotBlank(message = "공고타입은 빈 값일 수 없습니다. ALWAYS_OPEN (상시모집)과 LIMITED_TIME (기한한정)만 허용 가능합니다.")
         String announcementType,
-    List<@NotBlank(message = "각 동아리 태그는 빈값일 수 없습니다.") String> tags,
+    List<
+            @NotBlank(message = "각 공고 태그는 빈값일 수 없습니다.")
+            @Size(max = 20, message = "공고 태그 글자 수는 20자를 초과할 수 없습니다.") String>
+        tags,
     @Schema(description = "공고 지원서") @NotNull(message = "applicationForm 필드를 빈값으로 둘 수 없습니다.") @Valid
         ApplicationFormCreateRequest applicationForm,
     @Schema(description = "이미지 목록")

--- a/server/src/main/java/com/ryc/api/v2/announcement/presentation/dto/request/AnnouncementUpdateRequest.java
+++ b/server/src/main/java/com/ryc/api/v2/announcement/presentation/dto/request/AnnouncementUpdateRequest.java
@@ -30,7 +30,7 @@ import lombok.Builder;
 public record AnnouncementUpdateRequest(
     @Schema(description = "공고 제목", example = "2025년도 상반기 신입 모집")
         @NotBlank(message = "공고 제목은 필수 항목입니다.")
-        @Size(min = 2, max = 100, message = "공고 제목의 길이는 2자 이상 100자이하 입니다.")
+        @Size(min = 2, max = 200, message = "공고 제목의 길이는 2자 이상 200자이하 입니다.")
         String title,
     @Schema(description = "기간 정보")
         @NotNull(message = "공고 기한 정보 필드는 빈값일 수 없습니다. 최소 지원서 접수기간은 필수 입력해주십시오.")

--- a/server/src/main/java/com/ryc/api/v2/announcement/presentation/dto/request/AnnouncementUpdateRequest.java
+++ b/server/src/main/java/com/ryc/api/v2/announcement/presentation/dto/request/AnnouncementUpdateRequest.java
@@ -60,7 +60,10 @@ public record AnnouncementUpdateRequest(
             allowableValues = {"ALWAYS_OPEN", "LIMITED_TIME"})
         @NotBlank(message = "공고타입은 빈 값일 수 없습니다. ALWAYS_OPEN과 LIMITED_TIME만 허용 가능합니다.")
         String announcementType,
-    List<@NotBlank(message = "각 동아리 태그는 빈값일 수 없습니다.") String> tags,
+    List<
+            @NotBlank(message = "각 공고 태그는 빈값일 수 없습니다.")
+            @Size(max = 20, message = "공고 태그 글자 수는 20자를 초과할 수 없습니다.") String>
+        tags,
     @Schema(description = "공고 지원서") @NotNull(message = "applicationForm 필드를 빈값으로 둘 수 없습니다.") @Valid
         ApplicationFormUpdateRequest applicationForm,
     @Schema(description = "이미지 목록")

--- a/server/src/main/java/com/ryc/api/v2/announcement/service/AnnouncementService.java
+++ b/server/src/main/java/com/ryc/api/v2/announcement/service/AnnouncementService.java
@@ -95,10 +95,16 @@ public class AnnouncementService {
   public AnnouncementUpdateResponse updateAnnouncement(
       AnnouncementUpdateRequest request, String announcementId, String clubId) {
 
-    Announcement updateAnnouncement = Announcement.of(request, announcementId, clubId);
+    // 1. 기존 공고 상태 조회 및 상태검증
+    Announcement previousAnnouncement = announcementRepository.findById(announcementId);
+    if (AnnouncementStatus.UPCOMING != previousAnnouncement.getAnnouncementStatus()) {
+      throw new BusinessRuleException(AnnouncementErrorCode.INVALID_ANNOUNCEMENT_STATUS);
+    }
+
+    Announcement announcementToUpdate = Announcement.of(request, announcementId, clubId);
 
     // 2. 업데이트된 Announcement 저장
-    Announcement updatedAnnouncement = announcementRepository.save(updateAnnouncement);
+    Announcement updatedAnnouncement = announcementRepository.save(announcementToUpdate);
 
     // 3. 이미지 파일 업데이트
     if (request.images().size() > 10) {
@@ -114,7 +120,7 @@ public class AnnouncementService {
     fileService.claimOwnership(postImages, announcementId, FileDomainType.ANNOUNCEMENT_POST_IMAGE);
 
     fileService.claimOwnership(
-        request.images(), updateAnnouncement.getId(), FileDomainType.ANNOUNCEMENT_IMAGE);
+        request.images(), announcementToUpdate.getId(), FileDomainType.ANNOUNCEMENT_IMAGE);
 
     List<FileGetResponse> imageResponses =
         fileService.findAllByAssociatedId(announcementId).stream()

--- a/server/src/main/java/com/ryc/api/v2/auth/presentation/AuthController.java
+++ b/server/src/main/java/com/ryc/api/v2/auth/presentation/AuthController.java
@@ -67,7 +67,7 @@ public class AuthController {
   @ApiErrorCodeExample(
       value = {CommonErrorCode.class},
       include = {"RESOURCE_NOT_FOUND"})
-  public ResponseEntity<?> refreshToken(
+  public ResponseEntity<TokenRefreshResponse> refreshToken(
       @CookieValue("refresh-token") @NotBlank(message = "기존 리프레시 토큰은 빈값일 수 없습니다.") @JWT
           String refreshToken) {
     TokenRefreshResult refreshResult = authService.refreshToken(refreshToken);

--- a/server/src/main/java/com/ryc/api/v2/common/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/ryc/api/v2/common/exception/GlobalExceptionHandler.java
@@ -29,7 +29,9 @@ import com.ryc.api.v2.common.exception.event.DiscordInternalServerErrorEvent;
 import com.ryc.api.v2.common.exception.response.ErrorResponse;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestControllerAdvice
 @RequiredArgsConstructor
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
@@ -129,6 +131,9 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     // TODO: 예기치 못한 모든 예외는 해당 진입점으로 들어옴.
     //  현재 e.message는 errorCode의 메시지로 응답하는 형태. 예외 자체 메시지를 로그에 추가
     // DB에러와 같이 노출되면 안되는 값이 노출될 가능성. 절대 예외자체의 메시지를 응답값으로 넘기면 안됨. (errorCode의 메시지를 응답하기로 함.)
+
+    // TODO: 삭제 예정
+    log.error(errorCode.name(), e);
     return handleExceptionInternal(errorCode, request);
   }
 

--- a/server/src/main/java/com/ryc/api/v2/common/exception/code/InvalidFormatErrorCode.java
+++ b/server/src/main/java/com/ryc/api/v2/common/exception/code/InvalidFormatErrorCode.java
@@ -493,7 +493,7 @@ public enum InvalidFormatErrorCode implements ErrorCode {
 
   // Email Subject
   EMAIL_SUBJECT_NULL_OR_EMPTY(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 제목은 null 혹은 empty일 수 없습니다."),
-  EMAIL_INVALID_SUBJECT_LENGTH(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 제목은 1자 이상 255자 이하여야 합니다."),
+  EMAIL_INVALID_SUBJECT_LENGTH(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 제목은 1자 이상 1000자 이하여야 합니다."),
 
   // Email Content
   EMAIL_CONTENT_NULL_OR_EMPTY(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 내용은 null 혹은 empty일 수 없습니다."),

--- a/server/src/main/java/com/ryc/api/v2/common/exception/code/InvalidFormatErrorCode.java
+++ b/server/src/main/java/com/ryc/api/v2/common/exception/code/InvalidFormatErrorCode.java
@@ -64,7 +64,7 @@ public enum InvalidFormatErrorCode implements ErrorCode {
   ANNOUNCEMENT_TITLE_NULL_OR_EMPTY(
       HttpStatus.INTERNAL_SERVER_ERROR, "공고 제목은 null 혹은 empty일 수 없습니다."),
   ANNOUNCEMENT_INVALID_TITLE_LENGTH(
-      HttpStatus.INTERNAL_SERVER_ERROR, "공고 제목은 2자 이상 100자 이하여야 합니다."),
+      HttpStatus.INTERNAL_SERVER_ERROR, "공고 제목은 2자 이상 200자 이하여야 합니다."),
 
   // Announcement 모집인원
   ANNOUNCEMENT_NUMBER_OF_PEOPLE_EMPTY(HttpStatus.INTERNAL_SERVER_ERROR, "모집 인원은 empty일 수 없습니다."),

--- a/server/src/main/java/com/ryc/api/v2/email/domain/EmailValidator.java
+++ b/server/src/main/java/com/ryc/api/v2/email/domain/EmailValidator.java
@@ -24,7 +24,7 @@ final class EmailValidator extends DomainValidator {
   private static final int MAX_EMAIL_LOCAL_PART_LENGTH = 64;
   private static final int MAX_EMAIL_DOMAIN_PART_LENGTH = 253;
   private static final int MIN_SUBJECT_LENGTH = 1;
-  private static final int MAX_SUBJECT_LENGTH = 255;
+  private static final int MAX_SUBJECT_LENGTH = 1000;
   private static final int MIN_CONTENT_LENGTH = 1;
   private static final int MAX_CONTENT_LENGTH = 10000;
   private static final int MIN_RETRY_COUNT = 0;

--- a/server/src/main/java/com/ryc/api/v2/email/presentation/dto/request/EmailSendRequest.java
+++ b/server/src/main/java/com/ryc/api/v2/email/presentation/dto/request/EmailSendRequest.java
@@ -17,7 +17,7 @@ public record EmailSendRequest(
         List<@NotBlank(message = "수신자 이메일은 빈 값일 수 없습니다.") @Email String> recipients,
     @Schema(description = "메일 제목")
         @NotBlank(message = "메일 제목은 비워둘 수 없습니다.")
-        @Size(max = 255, message = "메일 제목은 255자를 초과할 수 없습니다.")
+        @Size(max = 1000, message = "메일 제목은 1000자를 초과할 수 없습니다.")
         String subject,
     @Schema(description = "메일 본문")
         @NotBlank(message = "메일 본문은 비워둘 수 없습니다.")


### PR DESCRIPTION
## 📌 관련 이슈
closed #480 

## 🛠️ 작업 내용
버그 목록
- [x] 1. [BE] 공고 제목 길이 검증 2자~200자로 수정(영문자 입력 가능성에 따른 수정)
- [x] 2. [BE] 메일제목 최대 길이 1000자로 수정 (영문자 입력 가능성에 따른 수정)
- [x] 3. [BE] 세션 만료시 로그아웃 API시 예상되지 않은 자체 500에러 발생. 쿠키관련하여 발생한 예외인 것 같아, 개발 배포환경 테스트를 위해 로그 추가
- [x] 4. [BE] 공고 태그라벨(값) 길이 오류시 400에러가 아닌 도메인 검증인 500에러 발생. 공고 생성/수정시에 DTO 검증 길이 검증 추가
- [x] 5. [BE] 모집 예정인 상태에서 모집 중인 상태로 공고 수정시 실패(예외코드: `INVALID_ANNOUNCEMENT_STATUS` 예외 메시지: `업데이트 시 공고는 모집예정 상태여야 합니다`. 발생) 
수정된 기한을 바탕으로 검증을 진행하기에 발생한 에러. 자세한 내용은 [버그 명세서](https://sangjunn.notion.site/BE-25e976a7f22380e28ebae23d894ac64d?source=copy_link) 확인 요망.
- [x] 6. [BE] 공고 수정시, 새로운 문항 추가시, 객관식 선지만 UUID 포멧 오류 문제. 사전질문, 질문id는 자체적으로 uuid를 생성해서 보내는 것 같은데, 객관식 선지는 "opt1" 이런식으로 생성 -> 프론트에 전달완료

## ⏳ 작업 시간
추정 시간:   3시간
실제 시간:   
이유: 차이가 많이 난다면 이유도 같이 적어주세요 :)
