### PR TITLE
[BE/HOTFIX] 면접 슬롯 생성: 2번이상 요청시 같은 시간대가 중복되어 누적되는 문제 발생 

### DIFF
--- a/server/src/main/java/com/ryc/api/v2/common/domain/Period.java
+++ b/server/src/main/java/com/ryc/api/v2/common/domain/Period.java
@@ -16,12 +16,7 @@ public record Period(LocalDateTime startDate, LocalDateTime endDate) {
 
   @Builder
   public Period {
-    LocalDateTime normalizedStartDate =
-        startDate() != null ? startDate().toLocalDate().atStartOfDay() : null;
-    LocalDateTime normalizedEndDate =
-        endDate() != null ? endDate().toLocalDate().atTime(23, 59, 59) : null;
-
-    PeriodValidator.validate(normalizedStartDate, normalizedEndDate);
+    PeriodValidator.validate(startDate, endDate);
   }
 
   public static Period from(PeriodRequest periodRequest) {

--- a/server/src/main/java/com/ryc/api/v2/interview/service/InterviewService.java
+++ b/server/src/main/java/com/ryc/api/v2/interview/service/InterviewService.java
@@ -190,6 +190,15 @@ public class InterviewService {
   public List<InterviewSlotCreateResponse> createInterviewSlots(
       String adminId, String clubId, String announcementId, InterviewSlotCreateRequest request) {
 
+    /**
+     * TODO: 현재 면접 타임대(슬롯)을 수정하는 기능을 서비스에서 제공하지 않음. 따라서 기존의 면접슬롯을 덮어씌우는 방식으로 구현. 추후 수정 기능 구현시 아래 로직
+     * 수정예정
+     */
+
+    // 기존의 인터뷰 슬롯 전체 삭제 후 새로운 인터뷰 슬롯으로 구성.
+    // TODO: 현재 연관관계 매핑과 CASCADE 설정으로 슬롯 삭제시 예약도 자동 삭제됨. 이 부분 논의 필요.
+    interviewRepository.deleteSlotsByAnnouncementId(announcementId);
+
     List<InterviewSlot> interviewSlots =
         request.numberOfPeopleByInterviewDateRequests().stream()
             .map(


### PR DESCRIPTION
## 📌 관련 이슈
closed #537 

## 🛠️ 작업 내용
- [x] Period 도메인 불필요한 날짜 정제 제거
- [x] 면접슬롯 새 생성 요청시, 기존 값 제거후 덮어씌우는 로직으로 수정

## 🎯 버그 사항
<img width="1624" height="1003" alt="Image" src="https://github.com/user-attachments/assets/e6fb9bde-19b1-42a4-b2ec-59b332faa25c" />
