### PR TITLE
[FE] UI 개선

### DIFF
--- a/monorepo/apps/admin/src/components/ErrorDialog/ErrorDialog.tsx
+++ b/monorepo/apps/admin/src/components/ErrorDialog/ErrorDialog.tsx
@@ -1,4 +1,8 @@
-import { DEFAULT_DESCRIPTION, ERROR_500_DESCRIPTION } from '@constants/errorText';
+import {
+    DEFAULT_DESCRIPTION,
+    ERROR_500_DESCRIPTION,
+    ERROR_500_DESCRIPTION_ADDITIONAL,
+} from '@constants/errorText';
 import { getErrorPlainMessageByErrorStatusCode } from '@utils/getErrorMessage';
 import React from 'react';
 
@@ -47,38 +51,41 @@ function ErrorDialog({
                         {subContent
                             ? subContent
                             : errorStatusCode === 500
-                              ? ERROR_500_DESCRIPTION
+                              ? ERROR_500_DESCRIPTION_ADDITIONAL
                               : DEFAULT_DESCRIPTION}
                     </Text>
                 </Dialog.Content>
                 <Dialog.Action position="center">
-                    {errorStatusCode === 500 ? (
-                        <div>
-                            <Button
-                                onClick={() => {
-                                    handleClose();
-                                    goTo('/');
-                                }}
-                            >
-                                오류 신고
-                            </Button>
-                        </div>
-                    ) : errorStatusCode === 401 ? (
-                        <div>
-                            <Button
-                                onClick={() => {
-                                    handleClose();
-                                    goTo('/login');
-                                }}
-                            >
-                                로그인 하기
-                            </Button>
-                        </div>
-                    ) : (
-                        <div>
-                            <Button onClick={() => handleClose}>확인</Button>
-                        </div>
-                    )}
+                    {
+                        // errorStatusCode === 500 ? (
+                        //     <div>
+                        //         <Button
+                        //             onClick={() => {
+                        //                 handleClose();
+                        //                 goTo('/');
+                        //             }}
+                        //         >
+                        //             오류 신고
+                        //         </Button>
+                        //     </div>
+                        // ) :
+                        errorStatusCode === 401 ? (
+                            <div>
+                                <Button
+                                    onClick={() => {
+                                        handleClose();
+                                        goTo('/login');
+                                    }}
+                                >
+                                    로그인 하기
+                                </Button>
+                            </div>
+                        ) : (
+                            <div>
+                                <Button onClick={() => handleClose}>확인</Button>
+                            </div>
+                        )
+                    }
                 </Dialog.Action>
             </Dialog>
         </>

--- a/monorepo/apps/admin/src/components/InterviewTimeTable/InterviewTimeTable.tsx
+++ b/monorepo/apps/admin/src/components/InterviewTimeTable/InterviewTimeTable.tsx
@@ -1,6 +1,6 @@
 import { InterviewInformationButton } from '@components';
 import dayjs from 'dayjs';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { Calendar, Divider, Text } from '@ssoc/ui';
 
@@ -26,11 +26,7 @@ function InterviewTimeTable({
     // lib hooks
     // initial values
     // state, ref, querystring hooks
-    const [highlightedDate, setHighlightedDate] = useState<string>(() => {
-        if (interviewSlots.length > 0 && interviewSlots[0].period.startDate)
-            return dayjs(interviewSlots[0].period.startDate).format('YYYY-MM-DD');
-        return '';
-    });
+    const [highlightedDate, setHighlightedDate] = useState<string>('');
 
     // form hooks
     // query hooks
@@ -56,7 +52,16 @@ function InterviewTimeTable({
             onOpenChange?.(false);
         }
     };
+
     // effects
+    useEffect(() => {
+        if (interviewSlots.length > 0 && selectedInterviewSlotId) {
+            const targetSlot = interviewSlots.find((slot) => slot.id === selectedInterviewSlotId);
+            if (targetSlot?.period?.startDate) {
+                setHighlightedDate(dayjs(targetSlot.period.startDate).format('YYYY-MM-DD'));
+            }
+        }
+    }, [interviewSlots, selectedInterviewSlotId]);
 
     return (
         <div css={[s_interviewTimeTableContainer, sx]}>

--- a/monorepo/apps/admin/src/constants/errorText.ts
+++ b/monorepo/apps/admin/src/constants/errorText.ts
@@ -9,3 +9,5 @@ export const DEFAULT_DESCRIPTION =
     '불편을 드려 죄송합니다.\n궁금한 점이 있으시면 언제든지 채널톡을 통해 문의해주세요!';
 export const ERROR_500_DESCRIPTION =
     '불편을 드려 죄송합니다.\n지속적으로 오류가 발생할 경우, 아래 버튼을 통해 오류 신고 부탁드립니다.';
+export const ERROR_500_DESCRIPTION_ADDITIONAL =
+    '불편을 드려 죄송합니다.\n지속적으로 오류가 발생할 경우, 오른쪽 하단 채널톡을 통해 오류 신고 부탁드려요!';

--- a/monorepo/apps/admin/src/pages/AnnouncementPage/PersonalQuestionPage/PersonalQuestion.style.ts
+++ b/monorepo/apps/admin/src/pages/AnnouncementPage/PersonalQuestionPage/PersonalQuestion.style.ts
@@ -61,3 +61,7 @@ export const s_fileUploaderSx = css`
 export const s_labelMultiline = css`
     white-space: pre-line;
 `;
+
+export const s_label = css`
+    color: ${theme.colors.gray[500]};
+`;

--- a/monorepo/apps/admin/src/pages/AnnouncementPage/PersonalQuestionPage/PersonalQuestionPage.tsx
+++ b/monorepo/apps/admin/src/pages/AnnouncementPage/PersonalQuestionPage/PersonalQuestionPage.tsx
@@ -6,6 +6,7 @@ import type { PersonalInfoPageProps } from '../types';
 import {
     s_fileUploaderSx,
     s_inputSx,
+    s_label,
     s_labelContainer,
     s_labelMultiline,
     s_labelSx,
@@ -87,7 +88,7 @@ function PersonalQuestionPage({ personalQuestions, containerStyle }: PersonalInf
                                 <Checkbox.Root key={option.id} disabled>
                                     <Checkbox.HiddenInput />
                                     <Checkbox.Control />
-                                    <Checkbox.Label>{option.option}</Checkbox.Label>
+                                    <Checkbox.Label sx={s_label}>{option.option}</Checkbox.Label>
                                 </Checkbox.Root>
                             ))}
                         </div>

--- a/monorepo/apps/admin/src/pages/ErrorFallbackPage/ErrorFallbackPage.tsx
+++ b/monorepo/apps/admin/src/pages/ErrorFallbackPage/ErrorFallbackPage.tsx
@@ -2,6 +2,7 @@ import AttentionTriangle from '@assets/images/attention-triangle.svg';
 import {
     DEFAULT_DESCRIPTION,
     ERROR_500_DESCRIPTION,
+    ERROR_500_DESCRIPTION_ADDITIONAL,
     ERROR_CODE_400,
     ERROR_CODE_401,
     ERROR_CODE_403,
@@ -83,23 +84,28 @@ function ErrorFallbackPage({ error, resetErrorBoundary }: ErrorFallbackPageProps
                     {message}
                 </Text>
                 <Text type="captionRegular">
-                    {error.statusCode === 500 ? ERROR_500_DESCRIPTION : DEFAULT_DESCRIPTION}
+                    {error.statusCode === 500
+                        ? ERROR_500_DESCRIPTION_ADDITIONAL
+                        : DEFAULT_DESCRIPTION}
                 </Text>
             </div>
-            {error.statusCode === 500 ? (
-                <div css={s_buttonContainer}>
-                    <Button onClick={() => goTo('/')}>오류 신고</Button>
-                    <Button onClick={resetErrorBoundary}>다시 시도</Button>
-                </div>
-            ) : error.statusCode === 401 ? (
-                <div css={s_buttonContainer}>
-                    <Button onClick={() => goTo('/login')}>로그인 하기</Button>
-                </div>
-            ) : (
-                <div css={s_buttonContainer}>
-                    <Button onClick={resetErrorBoundary}>다시 시도</Button>
-                </div>
-            )}
+            {
+                // error.statusCode === 500 ? (
+                //     <div css={s_buttonContainer}>
+                //         <Button onClick={() => goTo('/')}>오류 신고</Button>
+                //         <Button onClick={resetErrorBoundary}>다시 시도</Button>
+                //     </div>
+                // ) :
+                error.statusCode === 401 ? (
+                    <div css={s_buttonContainer}>
+                        <Button onClick={() => goTo('/login')}>로그인 하기</Button>
+                    </div>
+                ) : (
+                    <div css={s_buttonContainer}>
+                        <Button onClick={resetErrorBoundary}>다시 시도</Button>
+                    </div>
+                )
+            }
             <Button size="xs" variant="text" onClick={() => goTo('/')} sx={s_homeTextButton}>
                 처음으로
             </Button>

--- a/monorepo/apps/admin/src/pages/InterviewEvaluationPage/InterviewEvaluationPage.tsx
+++ b/monorepo/apps/admin/src/pages/InterviewEvaluationPage/InterviewEvaluationPage.tsx
@@ -141,7 +141,13 @@ function InterviewEvaluationPage() {
         if (slotId === null && interviewSlots.length > 0) {
             setSlotId(interviewSlots[0].id ?? '');
         }
-    }, [interviewSlots]);
+    }, [slotId, interviewSlots]);
+
+    useEffect(() => {
+        if (finalIntervieweeList.length === 0) {
+            setSelectedApplicant(null);
+        }
+    }, [finalIntervieweeList]);
 
     // etc
     function getEvaluationActionCallbacks(status: string) {

--- a/monorepo/apps/user/src/components/ErrorDialog/ErrorDialog.tsx
+++ b/monorepo/apps/user/src/components/ErrorDialog/ErrorDialog.tsx
@@ -1,4 +1,8 @@
-import { DEFAULT_DESCRIPTION, ERROR_500_DESCRIPTION } from '@constants/errorText';
+import {
+    DEFAULT_DESCRIPTION,
+    ERROR_500_DESCRIPTION,
+    ERROR_500_DESCRIPTION_ADDITIONAL,
+} from '@constants/errorText';
 import { getErrorPlainMessageByErrorStatusCode } from '@utils/getErrorMessage';
 import React from 'react';
 
@@ -47,38 +51,41 @@ function ErrorDialog({
                         {subContent
                             ? subContent
                             : errorStatusCode === 500
-                              ? ERROR_500_DESCRIPTION
+                              ? ERROR_500_DESCRIPTION_ADDITIONAL
                               : DEFAULT_DESCRIPTION}
                     </Text>
                 </Dialog.Content>
                 <Dialog.Action position="center">
-                    {errorStatusCode === 500 ? (
-                        <div>
-                            <Button
-                                onClick={() => {
-                                    handleClose();
-                                    goTo('/');
-                                }}
-                            >
-                                오류 신고
-                            </Button>
-                        </div>
-                    ) : errorStatusCode === 401 ? (
-                        <div>
-                            <Button
-                                onClick={() => {
-                                    handleClose();
-                                    goTo('/login');
-                                }}
-                            >
-                                로그인 하기
-                            </Button>
-                        </div>
-                    ) : (
-                        <div>
-                            <Button onClick={() => handleClose}>확인</Button>
-                        </div>
-                    )}
+                    {
+                        // errorStatusCode === 500 ? (
+                        //     <div>
+                        //         <Button
+                        //             onClick={() => {
+                        //                 handleClose();
+                        //                 goTo('/');
+                        //             }}
+                        //         >
+                        //             오류 신고
+                        //         </Button>
+                        //     </div>
+                        // ) :
+                        errorStatusCode === 401 ? (
+                            <div>
+                                <Button
+                                    onClick={() => {
+                                        handleClose();
+                                        goTo('/login');
+                                    }}
+                                >
+                                    로그인 하기
+                                </Button>
+                            </div>
+                        ) : (
+                            <div>
+                                <Button onClick={() => handleClose}>확인</Button>
+                            </div>
+                        )
+                    }
                 </Dialog.Action>
             </Dialog>
         </>

--- a/monorepo/apps/user/src/constants/errorText.ts
+++ b/monorepo/apps/user/src/constants/errorText.ts
@@ -9,3 +9,5 @@ export const DEFAULT_DESCRIPTION =
     '불편을 드려 죄송합니다.\n궁금한 점이 있으시면 언제든지 채널톡을 통해 문의해주세요!';
 export const ERROR_500_DESCRIPTION =
     '불편을 드려 죄송합니다.\n지속적으로 오류가 발생할 경우, 아래 버튼을 통해 오류 신고 부탁드립니다.';
+export const ERROR_500_DESCRIPTION_ADDITIONAL =
+    '불편을 드려 죄송합니다.\n지속적으로 오류가 발생할 경우, 오른쪽 하단 채널톡을 통해 오류 신고 부탁드려요!';

--- a/monorepo/apps/user/src/pages/ErrorFallbackPage/ErrorFallbackPage.tsx
+++ b/monorepo/apps/user/src/pages/ErrorFallbackPage/ErrorFallbackPage.tsx
@@ -2,6 +2,7 @@ import AttentionTriangle from '@assets/images/attention-triangle.svg';
 import {
     DEFAULT_DESCRIPTION,
     ERROR_500_DESCRIPTION,
+    ERROR_500_DESCRIPTION_ADDITIONAL,
     ERROR_CODE_400,
     ERROR_CODE_401,
     ERROR_CODE_403,
@@ -83,23 +84,28 @@ function ErrorFallbackPage({ error, resetErrorBoundary }: ErrorFallbackPageProps
                     {message}
                 </Text>
                 <Text type="captionRegular">
-                    {error.statusCode === 500 ? ERROR_500_DESCRIPTION : DEFAULT_DESCRIPTION}
+                    {error.statusCode === 500
+                        ? ERROR_500_DESCRIPTION_ADDITIONAL
+                        : DEFAULT_DESCRIPTION}
                 </Text>
             </div>
-            {error.statusCode === 500 ? (
-                <div css={s_buttonContainer}>
-                    <Button onClick={() => goTo('/')}>오류 신고</Button>
-                    <Button onClick={resetErrorBoundary}>다시 시도</Button>
-                </div>
-            ) : error.statusCode === 401 ? (
-                <div css={s_buttonContainer}>
-                    <Button onClick={() => goTo('/login')}>로그인 하기</Button>
-                </div>
-            ) : (
-                <div css={s_buttonContainer}>
-                    <Button onClick={resetErrorBoundary}>다시 시도</Button>
-                </div>
-            )}
+            {
+                // error.statusCode === 500 ? (
+                //     <div css={s_buttonContainer}>
+                //         <Button onClick={() => goTo('/')}>오류 신고</Button>
+                //         <Button onClick={resetErrorBoundary}>다시 시도</Button>
+                //     </div>
+                // ) :
+                error.statusCode === 401 ? (
+                    <div css={s_buttonContainer}>
+                        <Button onClick={() => goTo('/login')}>로그인 하기</Button>
+                    </div>
+                ) : (
+                    <div css={s_buttonContainer}>
+                        <Button onClick={resetErrorBoundary}>다시 시도</Button>
+                    </div>
+                )
+            }
             <Button size="xs" variant="text" onClick={() => goTo('/')} sx={s_homeTextButton}>
                 처음으로
             </Button>

--- a/monorepo/apps/user/src/pages/ReservationPage/ReservationPage.tsx
+++ b/monorepo/apps/user/src/pages/ReservationPage/ReservationPage.tsx
@@ -253,7 +253,7 @@ function ReservationPage() {
                             </div>
                             <Text type="captionSemibold" textAlign="end" noWrap>
                                 {selectedInterviewSlot
-                                    ? `잔여여석: ${selectedInterviewSlot?.currentNumberOfPeople} / ${selectedInterviewSlot?.maxNumberOfPeople}`
+                                    ? `잔여여석: ${(selectedInterviewSlot?.maxNumberOfPeople ?? 0) - (selectedInterviewSlot?.currentNumberOfPeople ?? 0)} / ${selectedInterviewSlot?.maxNumberOfPeople ?? 0}`
                                     : '시간을 선택해주세요'}
                             </Text>
                         </div>


### PR DESCRIPTION
## 📌 관련 이슈
`closed #540 `

## 🛠️ 작업 내용
PR에서 작업한 주요 내용을 적어주세요.
- [x] 면접 예약 페이지 잔여 여석 표시 방법 변경
- [x] 면접 평가 페이지 지원자 없을 경우, 인적 사항, 평가 등에서도 지원자 정보 안뜨게 변경
- [x] 관리자 페이지 내 모집 공고 - 사전 질문에서 라디오 label과 체크 박스 label 색 맞추기 (완전 똑같지는 않음)
- [x] Error Fallback ui 에서 500 에러 시 '오류 신고' 버튼 제거 -> 채널톡으로 신고하도록 유도

## 🎯 리뷰 포인트

## ⏳ 작업 시간
추정 시간:  45분
실제 시간:  45분
