### PR TITLE
[FE] 면접 일정 보내는 기능 이름 변경 및 tooltip 위치 변경

### DIFF
--- a/monorepo/apps/admin/src/components/CardBox/CardBox.style.ts
+++ b/monorepo/apps/admin/src/components/CardBox/CardBox.style.ts
@@ -74,7 +74,7 @@ export const s_meatballButton = css`
 `;
 
 export const s_dropdownContent = css`
-    width: 11.5rem;
+    width: 12.5rem;
 `;
 
 export const s_dropdownSeparator = css`

--- a/monorepo/apps/admin/src/components/CardBox/CardBox.tsx
+++ b/monorepo/apps/admin/src/components/CardBox/CardBox.tsx
@@ -255,7 +255,7 @@ function CardBox({
                                             disabled={isDisabled}
                                         >
                                             <Text as="text" type="subCaptionRegular">
-                                                면접 일정 보내기
+                                                면접 일정 설정 후 보내기
                                             </Text>
                                         </Dropdown.Item>
                                     </>

--- a/monorepo/apps/admin/src/components/InterviewSettingDialog/InterviewSettingDialog.style.ts
+++ b/monorepo/apps/admin/src/components/InterviewSettingDialog/InterviewSettingDialog.style.ts
@@ -231,3 +231,26 @@ export const s_editorTextarea = css`
         outline: none;
     }
 `;
+
+export const s_textAndTooltipContainer = css`
+    display: flex;
+    gap: 0.5rem;
+`;
+
+export const s_informSvgWrapper = css`
+    margin: 0.4rem 0 0 0;
+    align-items: center;
+`;
+
+export const s_informSvg = css`
+    width: 1.5rem;
+    height: 1.5rem;
+    color: ${theme.colors.gray[700]};
+    &:hover {
+        cursor: pointer;
+    }
+`;
+
+export const s_tooltipContent = css`
+    white-space: pre-line;
+`;

--- a/monorepo/apps/admin/src/components/InterviewSettingDialog/InterviewSettingDialog.tsx
+++ b/monorepo/apps/admin/src/components/InterviewSettingDialog/InterviewSettingDialog.tsx
@@ -1,4 +1,5 @@
 import type { InterviewDetailInformation } from '@api/domain/email/types';
+import Info from '@assets/images/info.svg';
 import XIcon from '@assets/images/xIcon.svg';
 import { InterviewTimeBox } from '@components';
 import {
@@ -13,7 +14,18 @@ import { convertImageToBase64 } from '@utils/convertImageToBase64';
 import dayjs from 'dayjs';
 import React, { useEffect, useMemo, useState } from 'react';
 
-import { Button, Calendar, Dialog, Divider, Editor, Input, Select, Text, useToast } from '@ssoc/ui';
+import {
+    Button,
+    Calendar,
+    Dialog,
+    Divider,
+    Editor,
+    Input,
+    Select,
+    Text,
+    Tooltip,
+    useToast,
+} from '@ssoc/ui';
 
 import {
     s_calendar,
@@ -27,6 +39,8 @@ import {
     s_emptyPlace,
     s_header,
     s_informationContainer,
+    s_informSvg,
+    s_informSvgWrapper,
     s_input,
     s_perInformationContainer,
     s_resetButton,
@@ -34,8 +48,10 @@ import {
     s_selectContainer,
     s_selectTrigger,
     s_submitButtonWrapper,
+    s_textAndTooltipContainer,
     s_titleInput,
     s_titleWrapper,
+    s_tooltipContent,
     s_verticalDivider,
 } from './InterviewSettingDialog.style';
 import { InterviewSettingDialogContext } from './InterviewSettingDialogContext';
@@ -220,9 +236,26 @@ function InterviewSettingDialog({
         <InterviewSettingDialogContext.Provider value={contextValue}>
             <Dialog open={open} handleClose={handleClose} size="full" sx={s_dialog}>
                 <Dialog.Header position="start" sx={s_header}>
-                    <Text as="span" type="bodyBold" sx={{ paddingTop: '0.3rem' }}>
-                        면접 일정 보내기
-                    </Text>
+                    <span css={s_textAndTooltipContainer}>
+                        <Text as="span" type="bodyBold" sx={{ paddingTop: '0.3rem' }}>
+                            면접 일정 설정 후 보내기
+                        </Text>
+                        <Tooltip
+                            content={`
+                                1. 면접 최대 인원 수와 면접 당 진행 시간을 먼저 정해주세요.\n
+                                2. 면접 날짜를 선택해주세요. (예: 9월 1일)\n
+                                3. 해당 날짜의 첫 시작 시간과 마지막 종료 시간을 선택해주세요. (예: 오전 10시 ~ 오후 3시)\n
+                                4. 선택하신 범위 내에서 진행 시간 단위로 슬롯이 자동으로 만들어져요. 원하는 슬롯을 선택해 확정해주세요.\n
+                                5. 다른 날짜도 같은 방식으로 설정하시면 모든 면접 일정이 확정돼요.\n
+                                6. 마지막으로 이메일 제목과 내용 모두 작성하신 뒤, '이메일 보내기' 버튼을 눌러주세요!\n
+                                `}
+                            direction="bottom"
+                            wrapperSx={s_informSvgWrapper}
+                            tooltipSx={s_tooltipContent}
+                        >
+                            <Info css={s_informSvg} />
+                        </Tooltip>
+                    </span>
                     <Button
                         variant="transparent"
                         size="xs"

--- a/monorepo/apps/admin/src/components/InterviewTimeBox/InterviewTimeBox.style.ts
+++ b/monorepo/apps/admin/src/components/InterviewTimeBox/InterviewTimeBox.style.ts
@@ -77,26 +77,3 @@ export const timeButtonCss = (active: boolean) => css`
         }
     `}
 `;
-
-export const s_textAndTooltipContainer = css`
-    display: flex;
-    gap: 0.5rem;
-`;
-
-export const s_informSvgWrapper = css`
-    margin: 0.1rem 0 0 0;
-    align-items: center;
-`;
-
-export const s_informSvg = css`
-    width: 1.5rem;
-    height: 1.5rem;
-    color: ${theme.colors.gray[700]};
-    &:hover {
-        cursor: pointer;
-    }
-`;
-
-export const s_tooltipContent = css`
-    white-space: pre-line;
-`;

--- a/monorepo/apps/admin/src/components/InterviewTimeBox/InterviewTimeBox.tsx
+++ b/monorepo/apps/admin/src/components/InterviewTimeBox/InterviewTimeBox.tsx
@@ -1,9 +1,8 @@
-import Info from '@assets/images/info.svg';
 import type { InterviewInformation } from '@components/InterviewSettingDialog/types';
 import { DEFAULT_END_TIME, DEFAULT_START_TIME } from '@constants/interviewSettingDialog';
 import React, { useCallback, useEffect, useMemo } from 'react';
 
-import { Tooltip, useToast } from '@ssoc/ui';
+import { useToast } from '@ssoc/ui';
 import { Button, Divider, Select, Text } from '@ssoc/ui';
 
 import { useInterviewSettingDialogContext } from '../InterviewSettingDialog/InterviewSettingDialogContext';
@@ -11,14 +10,10 @@ import {
     baseBox,
     dividerCss,
     s_applyButton,
-    s_informSvg,
-    s_informSvgWrapper,
     s_select,
     s_selectContent,
     s_selectTrigger,
-    s_textAndTooltipContainer,
     s_timeRangeSettingContainer,
-    s_tooltipContent,
     selectedTimeSection,
     timeButtonCss,
     timeSelectSection,
@@ -139,23 +134,9 @@ function InterviewTimeBox() {
     return (
         <div css={baseBox}>
             <div css={timeSelectSection}>
-                <span css={s_textAndTooltipContainer}>
-                    <Text as="span" type="captionSemibold">
-                        면접 진행 시간
-                    </Text>
-                    <Tooltip
-                        content={`1. 면접 날짜를 선택하세요. (예: 9월 1일)\n
-                            2. 각 면접의 진행 시간을 정하세요. (예: 30분)\n
-                            3. 해당 날짜의 첫 시작 시간과 마지막 종료 시간을 선택하세요. (예: 오전 10시 ~ 오후 3시)\n
-                            4. 선택된 범위 내에서 진행 시간 단위로 슬롯이 자동 생성됩니다. 원하는 슬롯을 선택해 확정하세요.\n
-                            5. 다른 날짜도 동일한 방식으로 설정하면, 모든 면접 일정이 확정됩니다.`}
-                        direction="right"
-                        wrapperSx={s_informSvgWrapper}
-                        tooltipSx={s_tooltipContent}
-                    >
-                        <Info css={s_informSvg} />
-                    </Tooltip>
-                </span>
+                <Text as="span" type="captionSemibold">
+                    면접 진행 시간
+                </Text>
                 <div css={s_timeRangeSettingContainer}>
                     <Select
                         value={startTime}


### PR DESCRIPTION
## 📌 관련 이슈
`closed #542 `

## 🛠️ 작업 내용
- [x] 면접 일정 보내는 기능 이름 변경 (면접 일정 보내기 -> 면접 일정 설정 후 보내기)
- [x] tooltip 위치 변경 (Dialog Header로 변경)

## 🎯 리뷰 포인트


## ⏳ 작업 시간
추정 시간:   15분
실제 시간:   15분
