### PR TITLE
[FE] 이메일 전송 실패 시 처리 방법 수정

### DIFF
--- a/monorepo/apps/admin/src/components/InterviewSettingDialog/InterviewSettingDialog.tsx
+++ b/monorepo/apps/admin/src/components/InterviewSettingDialog/InterviewSettingDialog.tsx
@@ -180,20 +180,11 @@ function InterviewSettingDialog({
             // eslint-disable-next-line no-empty
         }
 
-        if (handleInterviewEmail(interviewDetailInformationList, emailTitle, contentToSend)) {
+        if (await handleInterviewEmail(interviewDetailInformationList, emailTitle, contentToSend)) {
             handleReset();
             handleResetContent();
             handleClose();
         }
-        // if (
-        //     !open &&
-        //     interviewDetailInformationList.length !== 0 &&
-        //     emailTitle.length !== 0 &&
-        //     contentToSend.length !== 0
-        // ) {
-        //     handleReset();
-        //     handleResetContent();
-        // }
     };
 
     // effects

--- a/monorepo/apps/admin/src/components/InterviewSettingDialog/types.ts
+++ b/monorepo/apps/admin/src/components/InterviewSettingDialog/types.ts
@@ -8,7 +8,7 @@ export interface InterviewSettingDialogProps {
         numberOfPeopleByInterviewDateRequests: InterviewDetailInformation[],
         subject: string,
         content: string,
-    ) => boolean;
+    ) => Promise<boolean>;
 }
 
 export interface InterviewInformation {

--- a/monorepo/apps/admin/src/components/PlainEmailDialog/PlainEmailDialog.tsx
+++ b/monorepo/apps/admin/src/components/PlainEmailDialog/PlainEmailDialog.tsx
@@ -48,14 +48,10 @@ function PlainEmailDialog({ open, handleClose, handlePlainEmail }: PlainEmailDia
             // eslint-disable-next-line no-empty
         }
 
-        if (handlePlainEmail(emailTitle, contentToSend)) {
+        if (await handlePlainEmail(emailTitle, contentToSend)) {
             handleReset();
             handleClose();
         }
-
-        // if (!open && emailTitle.length !== 0 && contentToSend.length !== 0) {
-        //     handleReset();
-        // }
     };
 
     // effects

--- a/monorepo/apps/admin/src/components/PlainEmailDialog/types.ts
+++ b/monorepo/apps/admin/src/components/PlainEmailDialog/types.ts
@@ -1,5 +1,5 @@
 export interface PlainEmailDialogProps {
     open: boolean;
     handleClose: () => void;
-    handlePlainEmail: (subject: string, content: string) => boolean;
+    handlePlainEmail: (subject: string, content: string) => Promise<boolean>;
 }


### PR DESCRIPTION
## 📌 관련 이슈
`closed #546 `

## 🛠️ 작업 내용
- [x] mutate -> mutateAsync로 변경해 이메일 전송 실패 시 dialog 안꺼지도록 수정

## 🎯 리뷰 포인트

## ⏳ 작업 시간
추정 시간:   5분
실제 시간:   5분
