### PR TITLE
[FE/HOTFIX] 사이드바에서 동아리 생성 페이지로의 이동 제한

### DIFF
--- a/monorepo/apps/admin/src/components/SideBar/SideBar.tsx
+++ b/monorepo/apps/admin/src/components/SideBar/SideBar.tsx
@@ -20,7 +20,7 @@ import mainLogo from '@ssoc/assets/images/mainLogo.png';
 import Ryc from '@ssoc/assets/images/Ryc.svg';
 import UserSet from '@ssoc/assets/images/UserSet.svg';
 import { useRouter } from '@ssoc/hooks';
-import { Avatar, Button, Dropdown, Text, Tooltip } from '@ssoc/ui';
+import { Avatar, Button, Dropdown, Text, Tooltip, useToast } from '@ssoc/ui';
 
 import {
     addClubButton,
@@ -61,6 +61,7 @@ function SideBar() {
     const { clubId, announcementId } = useParams();
     const { goTo } = useRouter();
     const { logout } = useAuthStore();
+    const { toast } = useToast();
 
     // initial values
     const navMenu = useMemo(
@@ -312,7 +313,15 @@ function SideBar() {
                         ))}
                 </div>
                 <Tooltip content="동아리 생성" direction="bottomRight">
-                    <button css={addClubButton} onClick={() => goTo('/club-create')}>
+                    <button
+                        css={addClubButton}
+                        onClick={
+                            () =>
+                                toast.error(
+                                    '동아리 생성은 채널톡으로 직접 문의해주세요!',
+                                ) /*goTo('/club-create')*/
+                        }
+                    >
                         +
                     </button>
                 </Tooltip>


### PR DESCRIPTION
## 📌 관련 이슈
closed #551 

## 🛠️ 작업 내용
- [ ] 사이드바에서 동아리 생성페이지로 이동하는 로직 제거 및 toast 알림 추가


## ⏳ 작업 시간
추정 시간:   10분
실제 시간:   10분
