### PR TITLE
[FE] 면접 일정 관리 페이지 내 Dialog 확인 단계 추가

### DIFF
--- a/monorepo/apps/admin/src/components/InterviewTimeTable/InterviewTimeTable.tsx
+++ b/monorepo/apps/admin/src/components/InterviewTimeTable/InterviewTimeTable.tsx
@@ -82,22 +82,29 @@ function InterviewTimeTable({
                 </Text>
                 <div css={[s_interviewInformationButtonGroupWrapper(Boolean(slotsToShow)), listSx]}>
                     {slotsToShow.length > 0 ? (
-                        slotsToShow.map((slot) => {
-                            const startTime = dayjs(slot.period.startDate).format('HH:mm');
-                            const endTime = dayjs(slot.period.endDate).format('HH:mm');
-                            const label = `${dayjs(highlightedDate).format('MM월 DD일')} ${startTime}`;
+                        slotsToShow
+                            .slice()
+                            .sort((a, b) =>
+                                dayjs(a.period.startDate).isAfter(dayjs(b.period.startDate))
+                                    ? 1
+                                    : -1,
+                            )
+                            .map((slot) => {
+                                const startTime = dayjs(slot.period.startDate).format('HH:mm');
+                                const endTime = dayjs(slot.period.endDate).format('HH:mm');
+                                const label = `${dayjs(highlightedDate).format('MM월 DD일')} ${startTime}`;
 
-                            return (
-                                <InterviewInformationButton
-                                    key={slot.id}
-                                    label={label}
-                                    startTime={startTime}
-                                    endTime={endTime}
-                                    onClick={() => handleButtonClick(slot.id, label)}
-                                    isSelected={selectedInterviewSlotId === slot.id}
-                                />
-                            );
-                        })
+                                return (
+                                    <InterviewInformationButton
+                                        key={slot.id}
+                                        label={label}
+                                        startTime={startTime}
+                                        endTime={endTime}
+                                        onClick={() => handleButtonClick(slot.id, label)}
+                                        isSelected={selectedInterviewSlotId === slot.id}
+                                    />
+                                );
+                            })
                     ) : (
                         <Text as="span" type="captionSemibold">
                             등록된 면접 일정이 없습니다.

--- a/monorepo/apps/admin/src/pages/ApplicantSchedulePage/ApplicantSchedulePage.tsx
+++ b/monorepo/apps/admin/src/pages/ApplicantSchedulePage/ApplicantSchedulePage.tsx
@@ -8,7 +8,13 @@ import { useInterviewMutations } from '@api/hooks';
 import { interviewQueries, stepQueries } from '@api/queryFactory';
 import Alert from '@assets/images/alert.svg';
 import AttentionTriangle from '@assets/images/attention-triangle.svg';
-import { ApplicantList, ComponentMover, ErrorDialog, InterviewSlotDropdown } from '@components';
+import {
+    ApplicantList,
+    ComponentMover,
+    ConfirmDialog,
+    ErrorDialog,
+    InterviewSlotDropdown,
+} from '@components';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import type { Dispatch, SetStateAction } from 'react';
@@ -58,6 +64,10 @@ function ApplicantSchedulePage() {
         useState<SelectedLabel>({ label: '면접 일정 없음', interviewSlotId: null });
 
     const [errorDialogOpen, setErrorDialogOpen] = useState<boolean>(false);
+
+    const [openConfirmDialog, setOpenConfirmDialog] = useState<boolean>(false);
+    const [pendingAction, setPendingAction] = useState<(() => void) | null>(null);
+    const [confirmMessage, setConfirmMessage] = useState<string>('');
 
     // form hooks
     // query hooks
@@ -196,6 +206,46 @@ function ApplicantSchedulePage() {
         resetSelectedId('');
     };
 
+    const handleMoveWithConfirm = (
+        interviewees: InterviewApplicant[] | UnreservedApplicant[],
+        applicantId: string,
+        targetSlotId: string,
+        currentSlotId: string,
+        resetSelectedId: Dispatch<SetStateAction<string>>,
+    ) => {
+        if (interviewees === unreservedApplicants && targetSlotId !== '') {
+            setConfirmMessage(
+                `아직 예약하지 않은 지원자예요!\n\n ✔️임의로 면접 일정을 배정하시면\n지원자가 직접 예약할 수 없고 면접 확정 메일도 받을 수 없어요.\n\n그래도 진행하시겠어요?`,
+            );
+        } else if (
+            interviewees !== unreservedApplicants &&
+            targetSlotId !== '' &&
+            currentSlotId !== ''
+        ) {
+            setConfirmMessage(
+                `지원자의 면접 일정을 정말 변경하시겠어요?\n\n✔️ 변경된 일정은 자동으로 안내되지 않으니,\n꼭 지원자에게 별도로 알려주셔야 해요.`,
+            );
+        } else if (targetSlotId === '' && currentSlotId !== '') {
+            setConfirmMessage(
+                `지원자의 면접 일정을 해제하시겠어요?\n\n✔️미지정 상태가 되면, 지원자는 다시 직접 예약할 수 있어요.`,
+            );
+        }
+
+        setPendingAction(
+            () => () =>
+                handleMove(interviewees, applicantId, targetSlotId, currentSlotId, resetSelectedId),
+        );
+        setOpenConfirmDialog(true);
+    };
+
+    const handleConfirm = () => {
+        if (pendingAction) {
+            pendingAction();
+            setPendingAction(null);
+        }
+        setOpenConfirmDialog(false);
+    };
+
     // effects
     useEffect(() => {
         if (slot0Id === null && slot1Id === null && interviewSlots.length > 0) {
@@ -290,7 +340,7 @@ function ApplicantSchedulePage() {
                         <div css={s_arrowContainer}>
                             <ComponentMover
                                 onMoveLeft={() =>
-                                    handleMove(
+                                    handleMoveWithConfirm(
                                         isSelectedInThirdSlot
                                             ? unreservedApplicants
                                             : standardInterviewees,
@@ -304,7 +354,7 @@ function ApplicantSchedulePage() {
                                     )
                                 }
                                 onMoveRight={() =>
-                                    handleMove(
+                                    handleMoveWithConfirm(
                                         intervieweesToMove,
                                         selectedIntervieweeId,
                                         selectedStandardInterviewLabel.interviewSlotId ?? '',
@@ -334,7 +384,7 @@ function ApplicantSchedulePage() {
                         <div css={s_arrowContainer}>
                             <ComponentMover
                                 onMoveLeft={() =>
-                                    handleMove(
+                                    handleMoveWithConfirm(
                                         unreservedApplicants,
                                         selectedIntervieweeId,
                                         selectedStandardInterviewLabel.interviewSlotId ?? '',
@@ -343,7 +393,7 @@ function ApplicantSchedulePage() {
                                     )
                                 }
                                 onMoveRight={() =>
-                                    handleMove(
+                                    handleMoveWithConfirm(
                                         isSelectedInFirstSlot
                                             ? intervieweesToMove
                                             : standardInterviewees,
@@ -387,6 +437,18 @@ function ApplicantSchedulePage() {
                         </Text>
                     </div>
                 </div>
+            )}
+            {openConfirmDialog && (
+                <ConfirmDialog
+                    type="confirm"
+                    title="예약변경 알림"
+                    content={confirmMessage}
+                    open={true}
+                    cancelButton={true}
+                    handleClose={() => setOpenConfirmDialog(false)}
+                    actionHandler={handleConfirm}
+                    actionPosition="center"
+                />
             )}
         </>
     );


### PR DESCRIPTION
## 📌 관련 이슈
`closed #550 `

## 🛠️ 작업 내용
- [x] 면접 일정 관리 페이지 내 Dialog 확인 단계 추가
- [x] 면접 일정 버튼 시간순 정렬 

## 🎯 리뷰 포인트

## ⏳ 작업 시간
추정 시간:   30분
실제 시간:   30분
