### PR TITLE
[FE/HOTFIX] 면접 일정 관리 페이지 dialog 오류 개선

### DIFF
--- a/monorepo/apps/admin/src/pages/ApplicantSchedulePage/ApplicantSchedulePage.tsx
+++ b/monorepo/apps/admin/src/pages/ApplicantSchedulePage/ApplicantSchedulePage.tsx
@@ -229,6 +229,9 @@ function ApplicantSchedulePage() {
             setConfirmMessage(
                 `지원자의 면접 일정을 해제하시겠어요?\n\n✔️미지정 상태가 되면, 지원자는 다시 직접 예약할 수 있어요.`,
             );
+        } else {
+            toast('면접 일정이 없어요!', { toastTheme: 'colored', type: 'error' });
+            return;
         }
 
         setPendingAction(


### PR DESCRIPTION
## 📌 관련 이슈
`closed #555 `

## 🛠️ 작업 내용
- [x] 면접 일정이 존재하지 않는 상황에서 지원자 옮길 때 toast 알림 추가

## 🎯 리뷰 포인트

## ⏳ 작업 시간
추정 시간:   1분
실제 시간:   1분