### PR TITLE
[BE] 면접 타임대(슬롯) 생성/예약/변경 중복 제한 및 면접 타임대 정렬 후 데이터 제공으로 수정

### DIFF
--- a/server/src/main/java/com/ryc/api/v2/common/exception/code/InterviewErrorCode.java
+++ b/server/src/main/java/com/ryc/api/v2/common/exception/code/InterviewErrorCode.java
@@ -10,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 public enum InterviewErrorCode implements ErrorCode {
   INTERVIEW_SLOT_FULL(HttpStatus.CONFLICT, "해당 면접 슬롯의 예약이 모두 찼습니다."),
   INTERVIEW_SLOT_PERIOD_INVALID(HttpStatus.BAD_REQUEST, "면접 슬롯의 시작일과 종료일은 같은 날짜여야 합니다."),
-  APPLICANT_ALREADY_RESERVED(HttpStatus.CONFLICT, "해당 지원자는 이미 면접을 예약했습니다."),
+  APPLICANT_ALREADY_RESERVED(HttpStatus.CONFLICT, "해당 지원자는 이미 면접을 예약하였습니다."),
   ;
 
   private final HttpStatus httpStatus;

--- a/server/src/main/java/com/ryc/api/v2/interview/domain/InterviewRepository.java
+++ b/server/src/main/java/com/ryc/api/v2/interview/domain/InterviewRepository.java
@@ -24,6 +24,8 @@ public interface InterviewRepository {
 
   Boolean isReservedByAnnouncementIdAndApplicantId(String announcementId, String applicantId);
 
+  Boolean isReservedByApplicantId(String applicantId);
+
   void deleteSlotsByAnnouncementId(String announcementId);
 
   void deleteReservationById(String reservationId);

--- a/server/src/main/java/com/ryc/api/v2/interview/infra/InterviewRepositoryImpl.java
+++ b/server/src/main/java/com/ryc/api/v2/interview/infra/InterviewRepositoryImpl.java
@@ -78,6 +78,11 @@ public class InterviewRepositoryImpl implements InterviewRepository {
   }
 
   @Override
+  public Boolean isReservedByApplicantId(String applicantId) {
+    return interviewReservationJpaRepository.existsByApplicantId(applicantId);
+  }
+
+  @Override
   public void deleteSlotsByAnnouncementId(String announcementId) {
     interviewSlotJpaRepository.deleteAllByAnnouncementId(announcementId);
   }

--- a/server/src/main/java/com/ryc/api/v2/interview/infra/jpa/InterviewReservationJpaRepository.java
+++ b/server/src/main/java/com/ryc/api/v2/interview/infra/jpa/InterviewReservationJpaRepository.java
@@ -31,4 +31,6 @@ public interface InterviewReservationJpaRepository
     AND r.applicant.id = :applicantId
 """)
   Boolean existsByAnnouncementIdAndApplicantId(String announcementId, String applicantId);
+
+  Boolean existsByApplicantId(String applicantId);
 }

--- a/server/src/main/java/com/ryc/api/v2/interview/service/InterviewService.java
+++ b/server/src/main/java/com/ryc/api/v2/interview/service/InterviewService.java
@@ -20,6 +20,8 @@ import com.ryc.api.v2.club.domain.Club;
 import com.ryc.api.v2.club.domain.ClubRepository;
 import com.ryc.api.v2.common.dto.response.FileGetResponse;
 import com.ryc.api.v2.common.dto.response.PeriodResponse;
+import com.ryc.api.v2.common.exception.code.InterviewErrorCode;
+import com.ryc.api.v2.common.exception.custom.BusinessRuleException;
 import com.ryc.api.v2.email.domain.event.InterviewReservationEmailEvent;
 import com.ryc.api.v2.email.domain.event.InterviewSlotEmailEvent;
 import com.ryc.api.v2.file.domain.FileDomainType;
@@ -234,6 +236,9 @@ public class InterviewService {
   @Transactional
   public InterviewReservationCreateResponse reservationInterview(
       String slotId, InterviewReservationRequest body) {
+    // 지원자가 기존 예약 여부를 확인합니다.
+    if (interviewRepository.isReservedByApplicantId(body.applicantId()))
+      throw new BusinessRuleException(InterviewErrorCode.APPLICANT_ALREADY_RESERVED);
 
     // 요청된 면접 일정을 가져옵니다.
     InterviewSlot interviewSlot = interviewRepository.findSlotByIdForUpdate(slotId);

--- a/server/src/main/java/com/ryc/api/v2/interview/service/InterviewService.java
+++ b/server/src/main/java/com/ryc/api/v2/interview/service/InterviewService.java
@@ -53,7 +53,10 @@ public class InterviewService {
     List<InterviewSlot> interviewSlots =
         interviewRepository.findSlotsByAnnouncementId(announcementId);
 
-    return interviewSlots.stream().map(this::createInterviewSlotResponse).toList();
+    return interviewSlots.stream()
+        .sorted(Comparator.comparing(slot -> slot.getPeriod().startDate()))
+        .map(this::createInterviewSlotResponse)
+        .toList();
   }
 
   @Transactional(readOnly = true)


### PR DESCRIPTION
## 📌 관련 이슈
closed #554 

## 🛠️ 작업 내용
- [x] 관리자가 다시 면접 슬롯 생성 및 예약 안내 메일을 보내려 할때, 기존에 이미 생성된 슬롯이 있는 경우, 기존의 슬롯과 해당 슬롯의 예약자들의 예약 상태가 모두 초기화 된다고 안내
- [x] 이미 타임대(슬롯)을 예약한 지원자는 다시 예약 못하게 api 수정
- [x] 지원자 면접관리에서 면접 타임대 시간 순서대로 정렬하여 api 응답 제공으로 수정