### PR TITLE
[BE] InterviewReservation 생성자 수정

### DIFF
--- a/server/src/main/java/com/ryc/api/v2/interview/domain/InterviewReservation.java
+++ b/server/src/main/java/com/ryc/api/v2/interview/domain/InterviewReservation.java
@@ -3,9 +3,6 @@ package com.ryc.api.v2.interview.domain;
 import static com.ryc.api.v2.common.constant.DomainDefaultValues.DEFAULT_INITIAL_ID;
 
 import com.ryc.api.v2.applicant.domain.Applicant;
-import com.ryc.api.v2.applicant.domain.enums.ApplicantStatus;
-import com.ryc.api.v2.common.exception.code.InterviewErrorCode;
-import com.ryc.api.v2.common.exception.custom.InterviewException;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -20,10 +17,6 @@ public class InterviewReservation {
   @Builder
   private InterviewReservation(String id, Applicant applicant) {
     InterviewReservationValidator.validate(id, applicant);
-
-    if (applicant.getStatus() != ApplicantStatus.INTERVIEW_PENDING) {
-      throw new InterviewException(InterviewErrorCode.APPLICANT_STATUS_NOT_ELIGIBLE_FOR_INTERVIEW);
-    }
 
     this.id = id;
     this.applicant = applicant;

--- a/server/src/main/java/com/ryc/api/v2/interview/service/InterviewService.java
+++ b/server/src/main/java/com/ryc/api/v2/interview/service/InterviewService.java
@@ -245,6 +245,11 @@ public class InterviewService {
 
     // 지원자의 예약 정보를 생성합니다.
     Applicant applicant = applicantRepository.findById(body.applicantId());
+
+    if (applicant.getStatus() != ApplicantStatus.INTERVIEW_PENDING) {
+      throw new InterviewException(InterviewErrorCode.APPLICANT_STATUS_NOT_ELIGIBLE_FOR_INTERVIEW);
+    }
+
     InterviewReservation reservation = InterviewReservation.initialize(applicant);
 
     // 새로운 예약 정보를 저장합니다.
@@ -298,6 +303,12 @@ public class InterviewService {
     } else {
       // 기존 면접 슬롯이 없는 경우, 새로운 예약을 생성합니다.
       Applicant applicant = applicantRepository.findById(applicantId);
+
+      if (applicant.getStatus() != ApplicantStatus.INTERVIEW_PENDING) {
+        throw new InterviewException(
+            InterviewErrorCode.APPLICANT_STATUS_NOT_ELIGIBLE_FOR_INTERVIEW);
+      }
+
       reservation = InterviewReservation.initialize(applicant);
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
close #584

## 🛠️ 작업 내용
- [ ] 예외 처리를 Service Layer로 이동

## 🎯 리뷰 포인트
InterviewReservation 생명 주기는 지원자의 상태에 따라 생성될 수 있고 안될 수 있는 객체이면 안된다.
따라서 지원자의 상태를 고려한 예외 처리를 면접 예약 생성/수정 로직을 수행하는 서비스 메서드로 이관한다.