### PR TITLE
[BE] 면접 리마인더 조회 시 NPE 해결

### DIFF
--- a/server/src/main/java/com/ryc/api/v2/email/domain/EmailRepository.java
+++ b/server/src/main/java/com/ryc/api/v2/email/domain/EmailRepository.java
@@ -23,4 +23,6 @@ public interface EmailRepository {
   boolean existsByAnnouncementId(String announcementId);
 
   void deleteByStatus(EmailSentStatus status);
+
+  boolean existsByStatus(EmailSentStatus emailSentStatus);
 }

--- a/server/src/main/java/com/ryc/api/v2/email/domain/EmailVerificationRepository.java
+++ b/server/src/main/java/com/ryc/api/v2/email/domain/EmailVerificationRepository.java
@@ -17,4 +17,6 @@ public interface EmailVerificationRepository {
   void flush();
 
   void deleteAttemptedCodes();
+
+  boolean existsAttemptedCodes();
 }

--- a/server/src/main/java/com/ryc/api/v2/email/infra/EmailRepositoryImpl.java
+++ b/server/src/main/java/com/ryc/api/v2/email/infra/EmailRepositoryImpl.java
@@ -65,4 +65,9 @@ public class EmailRepositoryImpl implements EmailRepository {
   public void deleteByStatus(EmailSentStatus status) {
     emailJpaRepository.deleteByStatus(status);
   }
+
+  @Override
+  public boolean existsByStatus(EmailSentStatus emailSentStatus) {
+    return emailJpaRepository.existsByStatus(emailSentStatus);
+  }
 }

--- a/server/src/main/java/com/ryc/api/v2/email/infra/EmailVerificationRepositoryImpl.java
+++ b/server/src/main/java/com/ryc/api/v2/email/infra/EmailVerificationRepositoryImpl.java
@@ -67,4 +67,9 @@ public class EmailVerificationRepositoryImpl implements EmailVerificationReposit
   public void deleteAttemptedCodes() {
     jpaRepository.deleteByAttempted(true);
   }
+
+  @Override
+  public boolean existsAttemptedCodes() {
+    return jpaRepository.existsByAttempted(true);
+  }
 }

--- a/server/src/main/java/com/ryc/api/v2/email/infra/jpa/EmailJpaRepository.java
+++ b/server/src/main/java/com/ryc/api/v2/email/infra/jpa/EmailJpaRepository.java
@@ -24,4 +24,6 @@ public interface EmailJpaRepository extends JpaRepository<EmailEntity, String> {
   boolean existsByAnnouncementId(String announcementId);
 
   void deleteByStatus(EmailSentStatus status);
+
+  boolean existsByStatus(EmailSentStatus emailSentStatus);
 }

--- a/server/src/main/java/com/ryc/api/v2/email/infra/jpa/EmailVerificationJpaRepository.java
+++ b/server/src/main/java/com/ryc/api/v2/email/infra/jpa/EmailVerificationJpaRepository.java
@@ -16,4 +16,6 @@ public interface EmailVerificationJpaRepository
   Optional<EmailVerificationEntity> findByEmail(String email);
 
   void deleteByAttempted(boolean b);
+
+  boolean existsByAttempted(boolean b);
 }

--- a/server/src/main/java/com/ryc/api/v2/email/infra/scheduler/EmailCleanupScheduler.java
+++ b/server/src/main/java/com/ryc/api/v2/email/infra/scheduler/EmailCleanupScheduler.java
@@ -2,6 +2,7 @@ package com.ryc.api.v2.email.infra.scheduler;
 
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.ryc.api.v2.email.domain.EmailRepository;
 import com.ryc.api.v2.email.domain.EmailVerificationRepository;
@@ -17,12 +18,18 @@ public class EmailCleanupScheduler {
   private final EmailVerificationRepository emailVerificationRepository;
 
   @Scheduled(cron = "0 0 3 * * *")
+  @Transactional
   protected void cleanupSentEmails() {
-    emailRepository.deleteByStatus(EmailSentStatus.SENT);
+    if (emailRepository.existsByStatus(EmailSentStatus.SENT)) {
+      emailRepository.deleteByStatus(EmailSentStatus.SENT);
+    }
   }
 
   @Scheduled(cron = "0 0 4 * * *")
+  @Transactional
   protected void cleanupVerifiedEmails() {
-    emailVerificationRepository.deleteAttemptedCodes();
+    if (emailVerificationRepository.existsAttemptedCodes()) {
+      emailVerificationRepository.deleteAttemptedCodes();
+    }
   }
 }

--- a/server/src/main/java/com/ryc/api/v2/interview/presentation/dto/response/InterviewReminderTimeResponse.java
+++ b/server/src/main/java/com/ryc/api/v2/interview/presentation/dto/response/InterviewReminderTimeResponse.java
@@ -1,3 +1,3 @@
 package com.ryc.api.v2.interview.presentation.dto.response;
 
-public record InterviewReminderTimeResponse(String announcementId, int reminderTime) {}
+public record InterviewReminderTimeResponse(String announcementId, Integer reminderTime) {}


### PR DESCRIPTION
## 📌 관련 이슈
close #586

## 🛠️ 작업 내용
- [ ] ReponseDTO의 필드 중 remindTime 자료형을 int -> Integer 변경

## 🎯 리뷰 포인트
remindTime 필드는 null 값이 들어갈 수 있어야 하지만, int형으로 인해 NPE가 발생하는 오류가 존재하였다.
이를 참조타입인 Integer로 변경함으로써 NPE 문제를 해결하였다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 면접 예약 시 자격 미충족 지원자의 예약을 차단하여 잘못된 예약을 방지했습니다.
  - 정리 작업이 실제 데이터가 있을 때만 실행되도록 개선해 불필요한 삭제를 막았습니다.
  - 면접 알림 시간 응답이 null을 허용해 일부 경우의 오류를 방지했습니다.

- 리팩터링
  - 데이터 존재 여부 확인 로직과 트랜잭션 적용으로 정리 작업의 안정성과 일관성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->