### PR TITLE
[BE] OrphanImageCleanupScheduler NPE 문제 해결

### DIFF
--- a/server/src/main/java/com/ryc/api/v2/file/infra/mapper/FileMetaDataMapper.java
+++ b/server/src/main/java/com/ryc/api/v2/file/infra/mapper/FileMetaDataMapper.java
@@ -35,6 +35,7 @@ public class FileMetaDataMapper {
         .isDeleted(fileMetadataEntity.isDeleted())
         .accessToken(fileMetadataEntity.getAccessToken())
         .displayOrder(fileMetadataEntity.getDisplayOrder())
+        .createdAt(fileMetadataEntity.getCreatedAt())
         .build();
   }
 }

--- a/server/src/main/java/com/ryc/api/v2/file/service/FileService.java
+++ b/server/src/main/java/com/ryc/api/v2/file/service/FileService.java
@@ -224,6 +224,7 @@ public class FileService {
                 FileMetaData::getId, m -> FileGetResponse.of(m, getPrivateFileGetUrl(m))));
   }
 
+  @Transactional
   public void deleteOrphanImage() {
     List<FileMetaData> orphanImages =
         fileMetaDataRepository.findAll().stream()


### PR DESCRIPTION
FileMetaDataMapper 에서 domain 객체로의 매핑 과정중 createdAt 누락 및 service에 transactional 어노테이션 누락으로 인한 isDeleted 갱신 미적용 해결

## 📌 관련 이슈
#597 

## 🛠️ 작업 내용
PR에서 작업한 주요 내용을 적어주세요.
- [x] mapper 메소드 수정
- [x] service @transactional 어노테이션 추가 

## 🎯 리뷰 포인트

- 리뷰 포인트

## ⏳ 작업 시간
추정 시간:   20분
실제 시간:   20분
이유: 차이가 많이 난다면 이유도 같이 적어주세요 :)
